### PR TITLE
When building locally, the version should be based on the last tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN buildDeps=' \
         ' \
         set -x \
         && apk --no-cache add $buildDeps ca-certificates \
-        && wget -O sherpa https://github.com/jrasell/sherpa/releases/download/${SHERPA_VERSION}/sherpa-linux-amd64 \
+        && wget -O sherpa https://github.com/jrasell/sherpa/releases/download/v0.0.1/sherpa_0.0.1_linux_amd64 \
         && chmod +x /usr/bin/sherpa \
         && apk del $buildDeps \
         && echo "Build complete."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,7 +7,7 @@ tools: ## Install the tools used to test and build
 
 build: ## Build Sherpa for development purposes
 	@echo "==> Running $@..."
-	govvv build -o sherpa ./cmd -version local -pkg github.com/jrasell/sherpa/pkg/build
+	govvv build -o sherpa ./cmd -version $(shell git describe --tags --abbrev=0 $(git rev-list --tags --max-count=1) |cut -c 2- |awk '{print $1}')+dev -pkg github.com/jrasell/sherpa/pkg/build
 
 test: ## Run the Sherpa test suite with coverage
 	@echo "==> Running $@..."

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Sherpa is a job scaler for [HashiCorp Nomad](https://www.nomadproject.io/) and a
 
 ## Download & Install
 
-* The Sherpa binary can be downloaded from the [GitHub releases page](https://github.com/jrasell/sherpa/releases) using `curl -L https://github.com/jrasell/sherpa/releases/download/0.0.1/sherpa-linux-amd64 -o sherpa`
+* The Sherpa binary can be downloaded from the [GitHub releases page](https://github.com/jrasell/sherpa/releases) using `curl -L https://github.com/jrasell/sherpa/releases/download/v0.0.1/sherpa_0.0.1_linux_amd64 -o sherpa`
 
 * A docker image can be found on [Docker Hub](https://hub.docker.com/r/jrasell/sherpa/), the latest version can be downloaded using `docker pull jrasell/sherpa`.
 


### PR DESCRIPTION
When building locally using govvv, the version information should use the last git tag to provide greater visibility on the version and not just use a static string.