### PR TITLE
Internal autoscaling thresholds are now configurable within policy.

### DIFF
--- a/cmd/policy/init/command.go
+++ b/cmd/policy/init/command.go
@@ -6,6 +6,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	initPolicyCountSection = "{\"Enabled\":true,\"MaxCount\":16,\"MinCount\":4,\"ScaleOutCount\":2,\"ScaleInCount\":2,"
+	thresholdPolicySection = "\"ScaleOutCPUPercentageThreshold\":75,\"ScaleOutMemoryPercentageThreshold\":75,\"ScaleInCPUPercentageThreshold\":30,\"ScaleInMemoryPercentageThreshold\":30}"
+)
+
 func RegisterCommand(rootCmd *cobra.Command) error {
 	cmd := &cobra.Command{
 		Use:   "init",
@@ -20,5 +25,5 @@ func RegisterCommand(rootCmd *cobra.Command) error {
 }
 
 func runInit(_ *cobra.Command, _ []string) {
-	fmt.Println("{\"Enabled\": true,\"MaxCount\": 16,\"MinCount\": 4,\"ScaleOutCount\": 2,\"ScaleInCount\": 2}")
+	fmt.Println(initPolicyCountSection + thresholdPolicySection)
 }

--- a/pkg/api/policy.go
+++ b/pkg/api/policy.go
@@ -21,6 +21,11 @@ type JobGroupPolicy struct {
 	MinCount      int
 	ScaleOutCount int
 	ScaleInCount  int
+
+	ScaleOutCPUPercentageThreshold    int
+	ScaleOutMemoryPercentageThreshold int
+	ScaleInCPUPercentageThreshold     int
+	ScaleInMemoryPercentageThreshold  int
 }
 
 func (p *Policies) List() (*map[string]map[string]*JobGroupPolicy, error) {

--- a/pkg/autoscale/autoscale.go
+++ b/pkg/autoscale/autoscale.go
@@ -62,10 +62,10 @@ func (a *AutoScale) autoscaleJob(jobID string, policies map[string]*policy.Group
 		var count int
 
 		switch {
-		case cpuUsage < defaultCPUPercentageScaleInThreshold, memUsage < defaultMemoryPercentageScaleInThreshold:
+		case cpuUsage < pol.ScaleInCPUPercentageThreshold, memUsage < pol.ScaleInMemoryPercentageThreshold:
 			scalingDir = scale.DirectionIn
 			count = pol.ScaleInCount
-		case cpuUsage > defaultCPUPercentageScaleOutThreshold, memUsage > defaultMemoryPercentageScaleOutThreshold:
+		case cpuUsage > pol.ScaleOutCPUPercentageThreshold, memUsage > pol.ScaleOutMemoryPercentageThreshold:
 			scalingDir = scale.DirectionOut
 			count = pol.ScaleOutCount
 		}

--- a/pkg/autoscale/config.go
+++ b/pkg/autoscale/config.go
@@ -4,10 +4,3 @@ type Config struct {
 	ScalingInterval int
 	StrictChecking  bool
 }
-
-const (
-	defaultCPUPercentageScaleOutThreshold    = 80
-	defaultMemoryPercentageScaleOutThreshold = 80
-	defaultCPUPercentageScaleInThreshold     = 20
-	defaultMemoryPercentageScaleInThreshold  = 20
-)

--- a/pkg/policy/backend/memory/memory_test.go
+++ b/pkg/policy/backend/memory/memory_test.go
@@ -70,10 +70,14 @@ func TestPolicyBackend_Memory(t *testing.T) {
 
 func generateTestPolicy() *policy.GroupScalingPolicy {
 	return &policy.GroupScalingPolicy{
-		Enabled:       true,
-		MinCount:      1,
-		MaxCount:      10,
-		ScaleInCount:  1,
-		ScaleOutCount: 2,
+		Enabled:                           true,
+		MinCount:                          1,
+		MaxCount:                          10,
+		ScaleInCount:                      1,
+		ScaleOutCount:                     2,
+		ScaleOutCPUPercentageThreshold:    80,
+		ScaleInCPUPercentageThreshold:     20,
+		ScaleOutMemoryPercentageThreshold: 80,
+		ScaleInMemoryPercentageThreshold:  20,
 	}
 }

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -16,11 +16,21 @@ type GroupScalingPolicy struct {
 
 	// ScaleInCount is the number which a task group is decremented by during scaling.
 	ScaleInCount int `json:"ScaleInCount"`
+
+	ScaleOutCPUPercentageThreshold    int `json:"ScaleOutCPUPercentageThreshold"`
+	ScaleOutMemoryPercentageThreshold int `json:"ScaleOutMemoryPercentageThreshold"`
+
+	ScaleInCPUPercentageThreshold    int `json:"ScaleInCPUPercentageThreshold"`
+	ScaleInMemoryPercentageThreshold int `json:"ScaleInMemoryPercentageThreshold"`
 }
 
 const (
-	DefaultMinCount      = 2
-	DefaultMaxCount      = 10
-	DefaultScaleOutCount = 1
-	DefaultScaleInCount  = 1
+	DefaultMinCount                          = 2
+	DefaultMaxCount                          = 10
+	DefaultScaleOutCount                     = 1
+	DefaultScaleInCount                      = 1
+	DefaultScaleOutCPUPercentageThreshold    = 80
+	DefaultScaleOutMemoryPercentageThreshold = 80
+	DefaultScaleInCPUPercentageThreshold     = 20
+	DefaultScaleInMemoryPercentageThreshold  = 20
 )

--- a/pkg/policy/v1/policies_test.go
+++ b/pkg/policy/v1/policies_test.go
@@ -14,13 +14,17 @@ func Test_decodeGroupPolicyReqBodyAndValidate(t *testing.T) {
 		expectedErr    error
 	}{
 		{
-			body: []byte("{\"MaxCount\":10,\"MinCount\":2,\"Enabled\":true}"),
+			body: []byte("{\"MaxCount\":10,\"MinCount\":2,\"Enabled\":true,\"ScaleOutMemoryPercentageThreshold\":75}"),
 			expectedPolicy: &policy.GroupScalingPolicy{
-				Enabled:       true,
-				MaxCount:      10,
-				MinCount:      2,
-				ScaleInCount:  1,
-				ScaleOutCount: 1,
+				Enabled:                           true,
+				MaxCount:                          10,
+				MinCount:                          2,
+				ScaleInCount:                      1,
+				ScaleOutCount:                     1,
+				ScaleInCPUPercentageThreshold:     20,
+				ScaleOutCPUPercentageThreshold:    80,
+				ScaleInMemoryPercentageThreshold:  20,
+				ScaleOutMemoryPercentageThreshold: 75,
 			},
 			expectedErr: nil,
 		},

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -29,4 +29,16 @@ func MergeWithDefaults(pol *GroupScalingPolicy) {
 	if pol.ScaleInCount == 0 {
 		pol.ScaleInCount = DefaultScaleInCount
 	}
+	if pol.ScaleOutCPUPercentageThreshold == 0 {
+		pol.ScaleOutCPUPercentageThreshold = DefaultScaleOutCPUPercentageThreshold
+	}
+	if pol.ScaleOutMemoryPercentageThreshold == 0 {
+		pol.ScaleOutMemoryPercentageThreshold = DefaultScaleOutMemoryPercentageThreshold
+	}
+	if pol.ScaleInCPUPercentageThreshold == 0 {
+		pol.ScaleInCPUPercentageThreshold = DefaultScaleInCPUPercentageThreshold
+	}
+	if pol.ScaleInMemoryPercentageThreshold == 0 {
+		pol.ScaleInMemoryPercentageThreshold = DefaultScaleInMemoryPercentageThreshold
+	}
 }

--- a/pkg/policy/validate_test.go
+++ b/pkg/policy/validate_test.go
@@ -34,11 +34,15 @@ func Test_MergeWithDefaults(t *testing.T) {
 		{
 			policy: &GroupScalingPolicy{Enabled: true},
 			expectedResultPolicy: &GroupScalingPolicy{
-				Enabled:       true,
-				MinCount:      DefaultMinCount,
-				MaxCount:      DefaultMaxCount,
-				ScaleInCount:  DefaultScaleInCount,
-				ScaleOutCount: DefaultScaleOutCount,
+				Enabled:                           true,
+				MinCount:                          DefaultMinCount,
+				MaxCount:                          DefaultMaxCount,
+				ScaleInCount:                      DefaultScaleInCount,
+				ScaleOutCount:                     DefaultScaleOutCount,
+				ScaleOutCPUPercentageThreshold:    DefaultScaleOutCPUPercentageThreshold,
+				ScaleInCPUPercentageThreshold:     DefaultScaleInCPUPercentageThreshold,
+				ScaleOutMemoryPercentageThreshold: DefaultScaleOutMemoryPercentageThreshold,
+				ScaleInMemoryPercentageThreshold:  DefaultScaleInMemoryPercentageThreshold,
 			},
 		},
 	}

--- a/pkg/policy/watcher/consts.go
+++ b/pkg/policy/watcher/consts.go
@@ -1,9 +1,13 @@
 package watcher
 
 const (
-	metaKeyEnabled       = "sherpa_enabled"
-	metaKeyMaxCount      = "sherpa_max_count"
-	metaKeyMinCount      = "sherpa_min_count"
-	metaKeyScaleInCount  = "sherpa_scale_in_count"
-	metaKeyScaleOutCount = "sherpa_scale_out_count"
+	metaKeyEnabled                           = "sherpa_enabled"
+	metaKeyMaxCount                          = "sherpa_max_count"
+	metaKeyMinCount                          = "sherpa_min_count"
+	metaKeyScaleInCount                      = "sherpa_scale_in_count"
+	metaKeyScaleOutCount                     = "sherpa_scale_out_count"
+	metaKeyScaleOutCPUPercentageThreshold    = "sherpa_scale_out_cpu_percentage_threshold"
+	metaKeyScaleOutMemoryPercentageThreshold = "sherpa_scale_out_memory_percentage_threshold"
+	metaKeyScaleInCPUPercentageThreshold     = "sherpa_scale_in_cpu_percentage_threshold"
+	metaKeyScaleInMemoryPercentageThreshold  = "sherpa_scale_in_memory_percentage_threshold"
 )

--- a/pkg/policy/watcher/meta_keys.go
+++ b/pkg/policy/watcher/meta_keys.go
@@ -1,0 +1,163 @@
+package watcher
+
+import (
+	"strconv"
+
+	"github.com/jrasell/sherpa/pkg/policy"
+)
+
+func (m *MetaWatcher) readJobMeta(jobID string) {
+	info, _, err := m.nomad.Jobs().Info(jobID, nil)
+	if err != nil {
+		m.logger.Error().Err(err).Msg("failed to call Nomad API for job information")
+		return
+	}
+
+	for i := range info.TaskGroups {
+		if m.hasMetaKeys(info.TaskGroups[i].Meta) {
+			p := m.policyFromMeta(info.TaskGroups[i].Meta)
+
+			// Launch a go-routine to attempt to write the job policy to the
+			// backend store. If there is an error, we can't do anything but
+			// log it allowing for investigation if needed.
+			go func() {
+				if err := m.policies.PutJobGroupPolicy(jobID, *info.TaskGroups[i].Name, p); err != nil {
+					m.logger.Error().
+						Str("job", jobID).
+						Str("group", *info.TaskGroups[i].Name).
+						Err(err).
+						Msg("failed to add job group policy from Nomad meta")
+				}
+			}()
+		}
+	}
+}
+
+func (m *MetaWatcher) policyFromMeta(meta map[string]string) *policy.GroupScalingPolicy {
+	return &policy.GroupScalingPolicy{
+		MaxCount:                          m.maxCountValueOrDefault(meta),
+		MinCount:                          m.minCountValueOrDefault(meta),
+		Enabled:                           m.enabledValueOrDefault(meta),
+		ScaleInCount:                      m.scaleInValueOrDefault(meta),
+		ScaleOutCount:                     m.scaleOutValueOrDefault(meta),
+		ScaleOutCPUPercentageThreshold:    m.scaleOutCPUThresholdValueOrDefault(meta),
+		ScaleOutMemoryPercentageThreshold: m.scaleOutMemoryThresholdValueOrDefault(meta),
+		ScaleInCPUPercentageThreshold:     m.scaleInCPUThresholdValueOrDefault(meta),
+		ScaleInMemoryPercentageThreshold:  m.scaleInMemoryThresholdValueOrDefault(meta),
+	}
+}
+
+func (m *MetaWatcher) enabledValueOrDefault(meta map[string]string) bool {
+	if val, ok := meta[metaKeyEnabled]; ok {
+		enabled, err := strconv.ParseBool(val)
+		if err != nil {
+			m.logger.Error().Err(err).Msg("failed to convert max count meta value to int")
+			return false
+		}
+		return enabled
+	}
+	return false
+}
+
+func (m *MetaWatcher) maxCountValueOrDefault(meta map[string]string) int {
+	if val, ok := meta[metaKeyMaxCount]; ok {
+		maxInt, err := strconv.Atoi(val)
+		if err != nil {
+			m.logger.Error().Err(err).Msg("failed to convert max count meta value to int")
+			return policy.DefaultMaxCount
+		}
+		return maxInt
+	}
+	return policy.DefaultMaxCount
+}
+
+func (m *MetaWatcher) minCountValueOrDefault(meta map[string]string) int {
+	if val, ok := meta[metaKeyMinCount]; ok {
+		maxInt, err := strconv.Atoi(val)
+		if err != nil {
+			m.logger.Error().Err(err).Msg("failed to convert min count meta value to int")
+			return policy.DefaultMinCount
+		}
+		return maxInt
+	}
+	return policy.DefaultMinCount
+}
+
+func (m *MetaWatcher) scaleInValueOrDefault(meta map[string]string) int {
+	if val, ok := meta[metaKeyScaleInCount]; ok {
+		inCount, err := strconv.Atoi(val)
+		if err != nil {
+			m.logger.Error().Err(err).Msg("failed to convert scale in meta value to int")
+			return policy.DefaultScaleInCount
+		}
+		return inCount
+	}
+	return policy.DefaultScaleInCount
+}
+
+func (m *MetaWatcher) scaleOutValueOrDefault(meta map[string]string) int {
+	if val, ok := meta[metaKeyScaleOutCount]; ok {
+		outCount, err := strconv.Atoi(val)
+		if err != nil {
+			m.logger.Error().Err(err).Msg("failed to convert scale out meta value to int")
+			return policy.DefaultScaleOutCount
+		}
+		return outCount
+	}
+	return policy.DefaultScaleOutCount
+}
+
+func (m *MetaWatcher) scaleOutCPUThresholdValueOrDefault(meta map[string]string) int {
+	if val, ok := meta[metaKeyScaleOutCPUPercentageThreshold]; ok {
+		outThreshold, err := strconv.Atoi(val)
+		if err != nil {
+			m.logger.Error().Err(err).Msg("failed to convert scale out CPU meta value to int")
+			return policy.DefaultScaleOutCPUPercentageThreshold
+		}
+		return outThreshold
+	}
+	return policy.DefaultScaleOutCPUPercentageThreshold
+}
+
+func (m *MetaWatcher) scaleInCPUThresholdValueOrDefault(meta map[string]string) int {
+	if val, ok := meta[metaKeyScaleInCPUPercentageThreshold]; ok {
+		outThreshold, err := strconv.Atoi(val)
+		if err != nil {
+			m.logger.Error().Err(err).Msg("failed to convert scale in CPU meta value to int")
+			return policy.DefaultScaleInCPUPercentageThreshold
+		}
+		return outThreshold
+	}
+	return policy.DefaultScaleInCPUPercentageThreshold
+}
+
+func (m *MetaWatcher) scaleOutMemoryThresholdValueOrDefault(meta map[string]string) int {
+	if val, ok := meta[metaKeyScaleOutMemoryPercentageThreshold]; ok {
+		outThreshold, err := strconv.Atoi(val)
+		if err != nil {
+			m.logger.Error().Err(err).Msg("failed to convert scale out memory meta value to int")
+			return policy.DefaultScaleOutMemoryPercentageThreshold
+		}
+		return outThreshold
+	}
+	return policy.DefaultScaleOutMemoryPercentageThreshold
+}
+
+func (m *MetaWatcher) scaleInMemoryThresholdValueOrDefault(meta map[string]string) int {
+	if val, ok := meta[metaKeyScaleInMemoryPercentageThreshold]; ok {
+		outThreshold, err := strconv.Atoi(val)
+		if err != nil {
+			m.logger.Error().Err(err).Msg("failed to convert scale in memory meta value to int")
+			return policy.DefaultScaleInMemoryPercentageThreshold
+		}
+		return outThreshold
+	}
+	return policy.DefaultScaleInMemoryPercentageThreshold
+}
+
+func (m *MetaWatcher) hasMetaKeys(meta map[string]string) bool {
+	if _, ok := meta[metaKeyEnabled]; ok {
+		return true
+	}
+	return false
+}

--- a/pkg/policy/watcher/meta_keys_test.go
+++ b/pkg/policy/watcher/meta_keys_test.go
@@ -1,0 +1,127 @@
+package watcher
+
+import (
+	"testing"
+
+	"github.com/jrasell/sherpa/pkg/policy"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetaWatcher_policyFromMeta(t *testing.T) {
+	watcher := NewMetaWatcher(zerolog.Logger{}, nil, nil)
+
+	testCases := []struct {
+		meta           map[string]string
+		expectedPolicy *policy.GroupScalingPolicy
+	}{
+		{
+			meta: map[string]string{
+				metaKeyEnabled:                           "true",
+				metaKeyMaxCount:                          "100",
+				metaKeyMinCount:                          "50",
+				metaKeyScaleInCount:                      "3",
+				metaKeyScaleOutCount:                     "7",
+				metaKeyScaleOutCPUPercentageThreshold:    "95",
+				metaKeyScaleOutMemoryPercentageThreshold: "95",
+				metaKeyScaleInCPUPercentageThreshold:     "55",
+				metaKeyScaleInMemoryPercentageThreshold:  "55",
+			},
+			expectedPolicy: &policy.GroupScalingPolicy{
+				Enabled:                           true,
+				MinCount:                          50,
+				MaxCount:                          100,
+				ScaleOutCount:                     7,
+				ScaleInCount:                      3,
+				ScaleOutCPUPercentageThreshold:    95,
+				ScaleOutMemoryPercentageThreshold: 95,
+				ScaleInCPUPercentageThreshold:     55,
+				ScaleInMemoryPercentageThreshold:  55,
+			},
+		},
+		{
+			meta: map[string]string{
+				metaKeyEnabled: "true",
+			},
+			expectedPolicy: &policy.GroupScalingPolicy{
+				Enabled:                           true,
+				MinCount:                          2,
+				MaxCount:                          10,
+				ScaleOutCount:                     1,
+				ScaleInCount:                      1,
+				ScaleOutCPUPercentageThreshold:    80,
+				ScaleOutMemoryPercentageThreshold: 80,
+				ScaleInCPUPercentageThreshold:     20,
+				ScaleInMemoryPercentageThreshold:  20,
+			},
+		},
+		{
+			meta: map[string]string{
+				metaKeyEnabled: "false",
+			},
+			expectedPolicy: &policy.GroupScalingPolicy{
+				Enabled:                           false,
+				MinCount:                          2,
+				MaxCount:                          10,
+				ScaleOutCount:                     1,
+				ScaleInCount:                      1,
+				ScaleOutCPUPercentageThreshold:    80,
+				ScaleOutMemoryPercentageThreshold: 80,
+				ScaleInCPUPercentageThreshold:     20,
+				ScaleInMemoryPercentageThreshold:  20,
+			},
+		},
+		{
+			meta: map[string]string{
+				metaKeyEnabled:                           "true",
+				metaKeyMaxCount:                          "10000",
+				metaKeyScaleOutCount:                     "1000",
+				metaKeyScaleInCount:                      "10",
+				metaKeyScaleOutCPUPercentageThreshold:    "95",
+				metaKeyScaleOutMemoryPercentageThreshold: "75",
+				metaKeyScaleInCPUPercentageThreshold:     "15",
+				metaKeyScaleInMemoryPercentageThreshold:  "35",
+			},
+			expectedPolicy: &policy.GroupScalingPolicy{
+				Enabled:                           true,
+				MinCount:                          2,
+				MaxCount:                          10000,
+				ScaleOutCount:                     1000,
+				ScaleInCount:                      10,
+				ScaleOutCPUPercentageThreshold:    95,
+				ScaleOutMemoryPercentageThreshold: 75,
+				ScaleInCPUPercentageThreshold:     15,
+				ScaleInMemoryPercentageThreshold:  35,
+			},
+		},
+		{
+			meta: map[string]string{
+				metaKeyEnabled:                           "untranslatable",
+				metaKeyMinCount:                          "untranslatable",
+				metaKeyMaxCount:                          "untranslatable",
+				metaKeyScaleOutCount:                     "untranslatable",
+				metaKeyScaleInCount:                      "untranslatable",
+				metaKeyScaleOutCPUPercentageThreshold:    "untranslatable",
+				metaKeyScaleOutMemoryPercentageThreshold: "untranslatable",
+				metaKeyScaleInCPUPercentageThreshold:     "untranslatable",
+				metaKeyScaleInMemoryPercentageThreshold:  "untranslatable",
+			},
+			expectedPolicy: &policy.GroupScalingPolicy{
+				Enabled:                           false,
+				MinCount:                          2,
+				MaxCount:                          10,
+				ScaleOutCount:                     1,
+				ScaleInCount:                      1,
+				ScaleOutCPUPercentageThreshold:    80,
+				ScaleOutMemoryPercentageThreshold: 80,
+				ScaleInCPUPercentageThreshold:     20,
+				ScaleInMemoryPercentageThreshold:  20,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		actualPolicy := watcher.policyFromMeta(tc.meta)
+		assert.Equal(t, tc.expectedPolicy, actualPolicy)
+	}
+}

--- a/pkg/policy/watcher/watcher.go
+++ b/pkg/policy/watcher/watcher.go
@@ -1,11 +1,9 @@
 package watcher
 
 import (
-	"strconv"
 	"time"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/jrasell/sherpa/pkg/policy"
 	"github.com/jrasell/sherpa/pkg/policy/backend"
 	"github.com/rs/zerolog"
 )
@@ -61,106 +59,6 @@ func (m *MetaWatcher) Run() {
 		q.WaitIndex = maxFound
 		m.lastChangeIndex = maxFound
 	}
-}
-
-func (m *MetaWatcher) readJobMeta(jobID string) {
-	info, _, err := m.nomad.Jobs().Info(jobID, nil)
-	if err != nil {
-		m.logger.Error().Err(err).Msg("failed to call Nomad API for job information")
-		return
-	}
-
-	for i := range info.TaskGroups {
-		if m.hasMetaKeys(info.TaskGroups[i].Meta) {
-			p := m.policyFromMeta(info.TaskGroups[i].Meta)
-			go func() {
-				if err := m.policies.PutJobGroupPolicy(jobID, *info.TaskGroups[i].Name, p); err != nil {
-					m.logger.Error().
-						Str("job", jobID).
-						Str("group", *info.TaskGroups[i].Name).
-						Err(err).
-						Msg("failed to add job group policy from Nomad meta")
-				}
-			}()
-		}
-	}
-}
-
-func (m *MetaWatcher) policyFromMeta(meta map[string]string) *policy.GroupScalingPolicy {
-	return &policy.GroupScalingPolicy{
-		MaxCount:      m.maxCountValueOrDefault(meta),
-		MinCount:      m.minCountValueOrDefault(meta),
-		Enabled:       m.enabledValueOrDefault(meta),
-		ScaleInCount:  m.scaleInValueOrDefault(meta),
-		ScaleOutCount: m.scaleOutValueOrDefault(meta),
-	}
-}
-
-func (m *MetaWatcher) enabledValueOrDefault(meta map[string]string) bool {
-	if val, ok := meta[metaKeyEnabled]; ok {
-		enabled, err := strconv.ParseBool(val)
-		if err != nil {
-			m.logger.Error().Err(err).Msg("failed to convert max count meta value to int")
-			return false
-		}
-		return enabled
-	}
-	return false
-}
-
-func (m *MetaWatcher) maxCountValueOrDefault(meta map[string]string) int {
-	if val, ok := meta[metaKeyMaxCount]; ok {
-		maxInt, err := strconv.Atoi(val)
-		if err != nil {
-			m.logger.Error().Err(err).Msg("failed to convert max count meta value to int")
-			return policy.DefaultMaxCount
-		}
-		return maxInt
-	}
-	return policy.DefaultMaxCount
-}
-
-func (m *MetaWatcher) minCountValueOrDefault(meta map[string]string) int {
-	if val, ok := meta[metaKeyMinCount]; ok {
-		maxInt, err := strconv.Atoi(val)
-		if err != nil {
-			m.logger.Error().Err(err).Msg("failed to convert min count meta value to int")
-			return policy.DefaultMinCount
-		}
-		return maxInt
-	}
-	return policy.DefaultMinCount
-}
-
-func (m *MetaWatcher) scaleInValueOrDefault(meta map[string]string) int {
-	if val, ok := meta[metaKeyScaleInCount]; ok {
-		inCount, err := strconv.Atoi(val)
-		if err != nil {
-			m.logger.Error().Err(err).Msg("failed to convert scale in meta value to int")
-			return policy.DefaultScaleInCount
-		}
-		return inCount
-	}
-	return policy.DefaultScaleInCount
-}
-
-func (m *MetaWatcher) scaleOutValueOrDefault(meta map[string]string) int {
-	if val, ok := meta[metaKeyScaleOutCount]; ok {
-		outCount, err := strconv.Atoi(val)
-		if err != nil {
-			m.logger.Error().Err(err).Msg("failed to convert scale out meta value to int")
-			return policy.DefaultScaleOutCount
-		}
-		return outCount
-	}
-	return policy.DefaultScaleOutCount
-}
-
-func (m *MetaWatcher) hasMetaKeys(meta map[string]string) bool {
-	if _, ok := meta[metaKeyEnabled]; ok {
-		return true
-	}
-	return false
 }
 
 func (m *MetaWatcher) indexHasChange(new, old uint64) bool {

--- a/pkg/policy/watcher/watcher_test.go
+++ b/pkg/policy/watcher/watcher_test.go
@@ -3,96 +3,9 @@ package watcher
 import (
 	"testing"
 
-	"github.com/jrasell/sherpa/pkg/policy"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestMetaWatcher_policyFromMeta(t *testing.T) {
-	watcher := NewMetaWatcher(zerolog.Logger{}, nil, nil)
-
-	testCases := []struct {
-		meta           map[string]string
-		expectedPolicy *policy.GroupScalingPolicy
-	}{
-		{
-			meta: map[string]string{
-				metaKeyEnabled:       "true",
-				metaKeyMaxCount:      "100",
-				metaKeyMinCount:      "50",
-				metaKeyScaleInCount:  "3",
-				metaKeyScaleOutCount: "7",
-			},
-			expectedPolicy: &policy.GroupScalingPolicy{
-				Enabled:       true,
-				MinCount:      50,
-				MaxCount:      100,
-				ScaleOutCount: 7,
-				ScaleInCount:  3,
-			},
-		},
-		{
-			meta: map[string]string{
-				metaKeyEnabled: "true",
-			},
-			expectedPolicy: &policy.GroupScalingPolicy{
-				Enabled:       true,
-				MinCount:      2,
-				MaxCount:      10,
-				ScaleOutCount: 1,
-				ScaleInCount:  1,
-			},
-		},
-		{
-			meta: map[string]string{
-				metaKeyEnabled: "false",
-			},
-			expectedPolicy: &policy.GroupScalingPolicy{
-				Enabled:       false,
-				MinCount:      2,
-				MaxCount:      10,
-				ScaleOutCount: 1,
-				ScaleInCount:  1,
-			},
-		},
-		{
-			meta: map[string]string{
-				metaKeyEnabled:       "true",
-				metaKeyMaxCount:      "10000",
-				metaKeyScaleOutCount: "1000",
-				metaKeyScaleInCount:  "10",
-			},
-			expectedPolicy: &policy.GroupScalingPolicy{
-				Enabled:       true,
-				MinCount:      2,
-				MaxCount:      10000,
-				ScaleOutCount: 1000,
-				ScaleInCount:  10,
-			},
-		},
-		{
-			meta: map[string]string{
-				metaKeyEnabled:       "untranslatable",
-				metaKeyMinCount:      "untranslatable",
-				metaKeyMaxCount:      "untranslatable",
-				metaKeyScaleOutCount: "untranslatable",
-				metaKeyScaleInCount:  "untranslatable",
-			},
-			expectedPolicy: &policy.GroupScalingPolicy{
-				Enabled:       false,
-				MinCount:      2,
-				MaxCount:      10,
-				ScaleOutCount: 1,
-				ScaleInCount:  1,
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		policy := watcher.policyFromMeta(tc.meta)
-		assert.Equal(t, tc.expectedPolicy, policy)
-	}
-}
 
 func TestMetaWatcher_indexHasChange(t *testing.T) {
 	watcher := NewMetaWatcher(zerolog.Logger{}, nil, nil)


### PR DESCRIPTION
Previously the internal autoscaling thresholds for CPU and memory
were fixed at 80% and 20% using constants which could not be
changed by the user. This update now makes the thresholds
configurable via scaling policies so that users can customise the
thresholds per task group. If the user does not specify thresholds,
the 80:20 defaults will be used.