### PR TITLE
Fix incorrect error message return within Consul backend.

### DIFF
--- a/pkg/policy/backend/consul/consul.go
+++ b/pkg/policy/backend/consul/consul.go
@@ -123,7 +123,7 @@ func (p *PolicyBackend) PutJobPolicy(job string, groupPolicies map[string]*polic
 	}
 
 	if !success {
-		return errors.New("failed")
+		return errors.New("failed to write job policy Consul transaction")
 	}
 
 	return nil


### PR DESCRIPTION
The error return message was left in its development state and was
not helpful in indicating why Sherpa failed to write a job policy
to Consul. It has now been updated to contain some amount of
detail useful to an operator.