### PR TITLE
Updating autoscale resource usage % calculation to have multiplication first and then division

### DIFF
--- a/pkg/autoscale/autoscale.go
+++ b/pkg/autoscale/autoscale.go
@@ -51,8 +51,8 @@ func (a *AutoScale) autoscaleJob(jobID string, policies map[string]*policy.Group
 		// Maths. Find the current CPU and memory utilisation in percentage based on the total
 		// available resources to the group, compared to their configured maximum based on the
 		// resource stanza.
-		cpuUsage := resourceUsage[group].cpu / resourceInfo[group].cpu * 100
-		memUsage := resourceUsage[group].mem / resourceInfo[group].mem * 100
+		cpuUsage := resourceUsage[group].cpu * 100 / resourceInfo[group].cpu
+		memUsage := resourceUsage[group].mem * 100 / resourceInfo[group].mem
 		a.logger.Debug().
 			Int("mem-usage-percentage", memUsage).
 			Int("cpu-usage-percentage", cpuUsage).


### PR DESCRIPTION
Updating autoscale resource usage % calculation to have multiplication first and then division, so that <100% values don't round to 0%

<!--  Thanks for sending a pull request!  -->

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
