### PR TITLE
Fix bug where meta policy engine would not process job updates.

### DIFF
--- a/pkg/policy/watcher/meta_keys.go
+++ b/pkg/policy/watcher/meta_keys.go
@@ -7,6 +7,8 @@ import (
 )
 
 func (m *MetaWatcher) readJobMeta(jobID string) {
+	m.logger.Debug().Str("job", jobID).Msg("reading job group meta stanzas")
+
 	info, _, err := m.nomad.Jobs().Info(jobID, nil)
 	if err != nil {
 		m.logger.Error().Err(err).Msg("failed to call Nomad API for job information")

--- a/pkg/policy/watcher/watcher.go
+++ b/pkg/policy/watcher/watcher.go
@@ -65,7 +65,7 @@ func (m *MetaWatcher) Run() {
 				Str("job", jobs[i].ID).
 				Msg("job modify index has changed is greater than last recorded")
 
-			maxFound = jobs[i].ModifyIndex
+			maxFound = m.maxFound(jobs[i].ModifyIndex, maxFound)
 			go m.readJobMeta(jobs[i].ID)
 		}
 
@@ -82,4 +82,11 @@ func (m *MetaWatcher) indexHasChange(new, old uint64) bool {
 		return false
 	}
 	return true
+}
+
+func (m *MetaWatcher) maxFound(new, old uint64) uint64 {
+	if new <= old {
+		return old
+	}
+	return new
 }

--- a/pkg/policy/watcher/watcher_test.go
+++ b/pkg/policy/watcher/watcher_test.go
@@ -37,3 +37,39 @@ func TestMetaWatcher_indexHasChange(t *testing.T) {
 		assert.Equal(t, tc.expectedReturn, res)
 	}
 }
+
+func TestMetaWatcher_maxFound(t *testing.T) {
+	watcher := NewMetaWatcher(zerolog.Logger{}, nil, nil)
+
+	testCases := []struct {
+		newValue       uint64
+		oldValue       uint64
+		expectedReturn uint64
+	}{
+		{
+			newValue:       13,
+			oldValue:       7,
+			expectedReturn: 13,
+		},
+		{
+			newValue:       13696,
+			oldValue:       13696,
+			expectedReturn: 13696,
+		},
+		{
+			newValue:       7,
+			oldValue:       13,
+			expectedReturn: 13,
+		},
+		{
+			newValue:       1,
+			oldValue:       0,
+			expectedReturn: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		res := watcher.maxFound(tc.newValue, tc.oldValue)
+		assert.Equal(t, tc.expectedReturn, res)
+	}
+}


### PR DESCRIPTION
The meta policy watcher was doing an incorrect comparison when
checking whether the modify index on a job specification returned
from the API. Previously it was comparing against the maxfound
which was being set to the Jobs().List() returned meta. This meant
the job modify index would always be <= as it could never be
greater than the value of the API returned meta index.

In addition to fixing the above mentioned bug; this commit adds
some contextual logging around the meta watcher to help identify
any future issues and make operating in this mode easier.

Closes #15