### PR TITLE
Check error returned when calling Nomad Job Allocations in scaler.

### DIFF
--- a/pkg/autoscale/autoscale.go
+++ b/pkg/autoscale/autoscale.go
@@ -103,6 +103,10 @@ func (a *AutoScale) getJobAllocations(jobID string, policies map[string]*policy.
 	var allocList []*nomad.Allocation // nolint:prealloc
 
 	allocs, _, err := a.nomad.Jobs().Allocations(jobID, false, nil)
+	if err != nil {
+		return out, nil, err
+	}
+
 	for i := range allocs {
 
 		if !policies[allocs[i].TaskGroup].Enabled {


### PR DESCRIPTION
The autoscaler was making a call to the Nomad API without checking
the returned error. This commit ensures the error is checked
before continuing.