### PR TITLE
Use goroutine pool within autoscaler to limit concurrency.

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -6,6 +6,7 @@ The Sherpa server can be configured by supplying either CLI flags or using envir
 
 * `--autoscaler-enabled` (bool: false) - Enable the internal autoscaling engine.
 * `--autoscaler-evaluation-interval` (int: 60) - The time period in seconds between autoscaling evaluation runs.
+* `--autoscaler-num-threads` (int: 3) - Specifies the number of parallel autoscaler threads to run.
 * `--bind-addr` (string: "127.0.0.1) - The HTTP server address to bind to.
 * `--bind-port` (uint16: 8000) - The HTTP server port to bind to.
 * `--log-format` (string: "auto") - Specify the log format ("auto", "zerolog" or "human").

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/nomad/api v0.0.0-20190508234936-7ba2378a159e
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-isatty v0.0.7
+	github.com/panjf2000/ants v0.0.0-20190820151255-b60dfa8c16b0
 	github.com/pkg/errors v0.8.1
 	github.com/rs/zerolog v1.14.3
 	github.com/ryanuber/columnize v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,10 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/panjf2000/ants v0.0.0-20190820151255-b60dfa8c16b0 h1:otVy5M/CL7sQJRx9MxpFq3feQp7AEgx1Hp4/RPBRqkE=
+github.com/panjf2000/ants v0.0.0-20190820151255-b60dfa8c16b0/go.mod h1:AaACblRPzq35m1g3enqYcxspbbiOJJYaxU2wMpm1cXY=
+github.com/panjf2000/ants v1.2.0 h1:pMQ1/XpSgnWx3ro4y1xr/uA3jXUsTuAaU3Dm0JjwggE=
+github.com/panjf2000/ants v1.2.0/go.mod h1:AaACblRPzq35m1g3enqYcxspbbiOJJYaxU2wMpm1cXY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/pkg/autoscale/autoscale.go
+++ b/pkg/autoscale/autoscale.go
@@ -54,6 +54,8 @@ func (a *AutoScale) autoscaleJob(jobID string, policies map[string]*policy.Group
 		cpuUsage := resourceUsage[group].cpu * 100 / resourceInfo[group].cpu
 		memUsage := resourceUsage[group].mem * 100 / resourceInfo[group].mem
 		a.logger.Debug().
+			Str("job", jobID).
+			Str("group", group).
 			Int("mem-usage-percentage", memUsage).
 			Int("cpu-usage-percentage", cpuUsage).
 			Msg("resource utilisation calculation")

--- a/pkg/autoscale/config.go
+++ b/pkg/autoscale/config.go
@@ -2,5 +2,6 @@ package autoscale
 
 type Config struct {
 	ScalingInterval int
+	ScalingThreads  int
 	StrictChecking  bool
 }

--- a/pkg/autoscale/handler_test.go
+++ b/pkg/autoscale/handler_test.go
@@ -1,0 +1,28 @@
+package autoscale
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAutoScale_createWorkerPool(t *testing.T) {
+	testCases := []struct {
+		autoscaleStruct *AutoScale
+		expectedThreads int
+		testName        string
+	}{
+		{
+			autoscaleStruct: &AutoScale{cfg: &Config{ScalingThreads: 100}},
+			expectedThreads: 100,
+			testName:        "check worker pool number of concurrent threads",
+		},
+	}
+
+	for _, tc := range testCases {
+		pool, err := tc.autoscaleStruct.createWorkerPool()
+
+		assert.Nil(t, err, tc.testName)
+		assert.Equal(t, tc.expectedThreads, pool.Cap(), tc.testName)
+	}
+}

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -16,6 +16,8 @@ const (
 	configKeyBindPort                          = "bind-port"
 	configKeyAutoscalerEnabled                 = "autoscaler-enabled"
 	configKeyAutoscalerEvaluationInterval      = "autoscaler-evaluation-interval"
+	configKeyAutoscalerThreadNumber            = "autoscaler-num-threads"
+	configKeyAutoscalerThreadNumberDefault     = 3
 	configKeyPolicyEngineAPIEnabled            = "policy-engine-api-enabled"
 	configKeyPolicyEngineNomadMetaEnabled      = "policy-engine-nomad-meta-enabled"
 	configKeyPolicyEngineStrictCheckingEnabled = "policy-engine-strict-checking-enabled"
@@ -33,6 +35,7 @@ type Config struct {
 	InternalAutoScaler           bool
 	ConsulStorageBackend         bool
 	InternalAutoScalerEvalPeriod int
+	InternalAutoScalerNumThreads int
 }
 
 func (c *Config) MarshalZerologObject(e *zerolog.Event) {
@@ -43,6 +46,7 @@ func (c *Config) MarshalZerologObject(e *zerolog.Event) {
 		Bool(configKeyPolicyEngineStrictCheckingEnabled, c.StrictPolicyChecking).
 		Bool(configKeyAutoscalerEnabled, c.InternalAutoScaler).
 		Int(configKeyAutoscalerEvaluationInterval, c.InternalAutoScalerEvalPeriod).
+		Int(configKeyAutoscalerThreadNumber, c.InternalAutoScalerNumThreads).
 		Bool(configKeyStorageBackendConsulEnabled, c.ConsulStorageBackend).
 		Str(configKeyStorageBackendConsulPath, c.ConsulStorageBackendPath)
 }
@@ -56,6 +60,7 @@ func GetConfig() Config {
 		StrictPolicyChecking:         viper.GetBool(configKeyPolicyEngineStrictCheckingEnabled),
 		InternalAutoScaler:           viper.GetBool(configKeyAutoscalerEnabled),
 		InternalAutoScalerEvalPeriod: viper.GetInt(configKeyAutoscalerEvaluationInterval),
+		InternalAutoScalerNumThreads: viper.GetInt(configKeyAutoscalerThreadNumber),
 		ConsulStorageBackend:         viper.GetBool(configKeyStorageBackendConsulEnabled),
 		ConsulStorageBackendPath:     viper.GetString(configKeyStorageBackendConsulPath),
 	}
@@ -148,6 +153,19 @@ func RegisterConfig(cmd *cobra.Command) {
 			longOpt      = "autoscaler-evaluation-interval"
 			defaultValue = configKeyAutoscalerEvaluationIntervalDefault
 			description  = "The time period in seconds between autoscaling evaluation runs"
+		)
+
+		flags.Int(longOpt, defaultValue, description)
+		_ = viper.BindPFlag(key, flags.Lookup(longOpt))
+		viper.SetDefault(key, defaultValue)
+	}
+
+	{
+		const (
+			key          = configKeyAutoscalerThreadNumber
+			longOpt      = "autoscaler-num-threads"
+			defaultValue = configKeyAutoscalerThreadNumberDefault
+			description  = "Specifies the number of parallel autoscaler threads to run"
 		)
 
 		flags.Int(longOpt, defaultValue, description)

--- a/pkg/config/server/server_test.go
+++ b/pkg/config/server/server_test.go
@@ -19,4 +19,5 @@ func Test_ServerConfig(t *testing.T) {
 	assert.Equal(t, true, cfg.StrictPolicyChecking)
 	assert.Equal(t, false, cfg.InternalAutoScaler)
 	assert.Equal(t, configKeyStorageBackendConsulPathDefault, cfg.ConsulStorageBackendPath)
+	assert.Equal(t, configKeyAutoscalerThreadNumberDefault, cfg.InternalAutoScalerNumThreads)
 }

--- a/vendor/github.com/panjf2000/ants/.gitignore
+++ b/vendor/github.com/panjf2000/ants/.gitignore
@@ -1,0 +1,17 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+.idea

--- a/vendor/github.com/panjf2000/ants/.travis.yml
+++ b/vendor/github.com/panjf2000/ants/.travis.yml
@@ -1,0 +1,18 @@
+language: go
+
+go:
+  - "1.8.x"
+  - "1.9.x"
+  - "1.10.x"
+  - "1.11.x"
+  - "1.12.x"
+
+before_install:
+  - go get -t -v ./...
+
+script:
+  #- go test -cpu=16 -bench=. -benchmem=true -run=none ./...
+  - go test -race -coverprofile=coverage.txt -covermode=atomic -v
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/vendor/github.com/panjf2000/ants/LICENSE
+++ b/vendor/github.com/panjf2000/ants/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Andy Pan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/panjf2000/ants/README.md
+++ b/vendor/github.com/panjf2000/ants/README.md
@@ -1,0 +1,289 @@
+# ants
+<p align="center">
+<img src="https://user-images.githubusercontent.com/7496278/51748488-8efd2600-20e7-11e9-91f5-1c5b466dcca1.jpg"/>
+A goroutine pool for Go
+<br/><br/>
+<a title="Build Status" target="_blank" href="https://travis-ci.com/panjf2000/ants"><img src="https://img.shields.io/travis/com/panjf2000/ants?style=flat-square"></a>
+<a title="Codecov" target="_blank" href="https://codecov.io/gh/panjf2000/ants"><img src="https://img.shields.io/codecov/c/github/panjf2000/ants?style=flat-square"></a>
+<a title="Go Report Card" target="_blank" href="https://goreportcard.com/report/github.com/panjf2000/ants"><img src="https://goreportcard.com/badge/github.com/panjf2000/ants?style=flat-square"></a>
+<a title="Ants on Sourcegraph" target="_blank" href="https://sourcegraph.com/github.com/panjf2000/ants?badge"><img src="https://sourcegraph.com/github.com/panjf2000/ants/-/badge.svg?style=flat-square"></a>
+<br/>
+<a title="" target="_blank" href="https://golangci.com/r/github.com/panjf2000/ants"><img src="https://golangci.com/badges/github.com/panjf2000/ants.svg"></a>
+<a title="Godoc for ants" target="_blank" href="https://godoc.org/github.com/panjf2000/ants"><img src="https://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square"></a>
+<a title="Release" target="_blank" href="https://github.com/panjf2000/ants/releases"><img src="https://img.shields.io/github/release/panjf2000/ants.svg?style=flat-square"></a>
+<a title="License" target="_blank" href="https://opensource.org/licenses/mit-license.php"><img src="https://img.shields.io/aur/license/pac?style=flat-square"></a>
+</p>
+
+[中文](README_ZH.md) | [Project Blog](https://taohuawu.club/high-performance-implementation-of-goroutine-pool)
+
+Library `ants` implements a goroutine pool with fixed capacity, managing and recycling a massive number of goroutines, allowing developers to limit the number of goroutines in your concurrent programs.
+
+## Features:
+
+- Automatically managing and recycling a massive number of goroutines.
+- Periodically purging overdue goroutines.
+- Friendly interfaces: submitting tasks, getting the number of running goroutines, tuning capacity of pool dynamically, closing pool.
+- Handle panic gracefully to prevent programs from crash.
+- Efficient in memory usage and it even achieves higher performance than unlimited goroutines in golang.
+
+## Tested in the following Golang versions:
+
+- 1.8.x
+- 1.9.x
+- 1.10.x
+- 1.11.x
+- 1.12.x
+
+
+## How to install
+
+``` sh
+go get -u github.com/panjf2000/ants
+```
+
+## How to use
+Just take a imagination that your program starts a massive number of goroutines, from which a vast amount of memory will be consumed. To mitigate that kind of situation, all you need to do is to import `ants` package and submit all your tasks to a default pool with fixed capacity, activated when package `ants` is imported:
+
+``` go
+package main
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/panjf2000/ants"
+)
+
+var sum int32
+
+func myFunc(i interface{}) {
+	n := i.(int32)
+	atomic.AddInt32(&sum, n)
+	fmt.Printf("run with %d\n", n)
+}
+
+func demoFunc() {
+	time.Sleep(10 * time.Millisecond)
+	fmt.Println("Hello World!")
+}
+
+func main() {
+	defer ants.Release()
+
+	runTimes := 1000
+
+	// Use the common pool.
+	var wg sync.WaitGroup
+	syncCalculateSum := func() {
+		demoFunc()
+		wg.Done()
+	}
+	for i := 0; i < runTimes; i++ {
+		wg.Add(1)
+		_ = ants.Submit(syncCalculateSum)
+	}
+	wg.Wait()
+	fmt.Printf("running goroutines: %d\n", ants.Running())
+	fmt.Printf("finish all tasks.\n")
+
+	// Use the pool with a method,
+	// set 10 to the capacity of goroutine pool and 1 second for expired duration.
+	p, _ := ants.NewPoolWithFunc(ants.Options{Capacity: 10, PoolFunc: func(i interface{}) {
+		myFunc(i)
+		wg.Done()
+	}})
+	defer p.Release()
+	// Submit tasks one by one.
+	for i := 0; i < runTimes; i++ {
+		wg.Add(1)
+		_ = p.Invoke(int32(i))
+	}
+	wg.Wait()
+	fmt.Printf("running goroutines: %d\n", p.Running())
+	fmt.Printf("finish all tasks, result is %d\n", sum)
+}
+```
+
+## Integrate with http server
+```go
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"github.com/panjf2000/ants"
+)
+
+type Request struct {
+	Param  []byte
+	Result chan []byte
+}
+
+func main() {
+  pool, _ := ants.NewPoolWithFunc(ants.Options{Capacity:100, PoolFunc:func(payload interface{}) {
+		request, ok := payload.(*Request)
+		if !ok {
+			return
+		}
+		reverseParam := func(s []byte) []byte {
+			for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+				s[i], s[j] = s[j], s[i]
+			}
+			return s
+		}(request.Param)
+
+		request.Result <- reverseParam
+  }})
+	defer pool.Release()
+
+	http.HandleFunc("/reverse", func(w http.ResponseWriter, r *http.Request) {
+		param, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "request error", http.StatusInternalServerError)
+		}
+		defer r.Body.Close()
+
+		request := &Request{Param: param, Result: make(chan []byte)}
+
+		// Throttle the requests traffic with ants pool. This process is asynchronous and
+		// you can receive a result from the channel defined outside.
+		if err := pool.Invoke(request); err != nil {
+			http.Error(w, "throttle limit error", http.StatusInternalServerError)
+		}
+
+		w.Write(<-request.Result)
+	})
+
+	http.ListenAndServe(":8080", nil)
+}
+```
+
+## Options for ants pool
+
+```go
+type Options struct {
+	// Capacity of the pool.
+	Capacity int
+
+	// ExpiryDuration set the expired time (second) of every worker.
+	ExpiryDuration time.Duration
+
+	// PreAlloc indicate whether to make memory pre-allocation when initializing Pool.
+	PreAlloc bool
+
+	// Max number of goroutine blocking on pool.Submit.
+	// 0 (default value) means no such limit.
+	MaxBlockingTasks int
+
+	// When Nonblocking is true, Pool.Submit will never be blocked.
+	// ErrPoolOverload will be returned when Pool.Submit cannot be done at once.
+	// When Nonblocking is true, MaxBlockingTasks is inoperative.
+	Nonblocking bool
+
+	// PanicHandler is used to handle panics from each worker goroutine.
+	// if nil, panics will be thrown out again from worker goroutines.
+	PanicHandler func(interface{})
+
+	// poolFunc is the function for processing tasks.
+	PoolFunc func(interface{})
+}
+```
+
+`ants.Options`contains all configurations of ants pool, which allow you to customize the goroutine pool by setting up each field in it, then passing it to `NewPool`method.
+
+## Customize limited pool
+
+`ants` also supports customizing the capacity of pool. You can invoke the `NewPool` method to instantiate a pool with a given capacity, as following:
+
+``` go
+// Set 10000 the size of goroutine pool
+p, _ := ants.NewPool(ants.Options{Capacity: 10000})
+```
+
+## Submit tasks
+Tasks can be submitted by calling `ants.Submit(func())`
+```go
+ants.Submit(func(){})
+```
+
+## Tune pool capacity in runtime
+You can tune the capacity of  `ants` pool in runtime with `Tune(int)`:
+
+``` go
+pool.Tune(1000) // Tune its capacity to 1000
+pool.Tune(100000) // Tune its capacity to 100000
+```
+
+Don't worry about the synchronous problems in this case, the method here is thread-safe (or should be called goroutine-safe).
+
+## Pre-malloc goroutine queue in pool
+
+`ants` allows you to pre-allocate memory of goroutine queue in pool, which may get a performance enhancement under some special certain circumstances such as the scenario that requires an pool with ultra-large capacity, meanwhile each task in goroutine lasts for a long time, in this case, pre-mallocing will reduce a lot of costs when re-slicing goroutine queue.
+
+```go
+// ants will pre-malloc the whole capacity of pool when you invoke this method
+p, _ := ants.NewPool(ants.Options{Capacity: AntsSize, PreAlloc: true})
+```
+
+## Release Pool
+
+```go
+pool.Release()
+```
+
+## About sequence
+All tasks submitted to `ants` pool will not be guaranteed to be addressed in order, because those tasks scatter among a series of concurrent workers, thus those tasks would be executed concurrently.
+
+## Benchmarks
+
+```
+OS: macOS High Sierra
+Processor: 2.7 GHz Intel Core i5
+Memory: 8 GB 1867 MHz DDR3
+
+Go Version: 1.9
+```
+
+<div align="center"><img src="https://user-images.githubusercontent.com/7496278/51515466-c7ce9e00-1e4e-11e9-89c4-bd3785b3c667.png"/></div>
+ In that benchmark-picture, the first and second benchmarks performed test cases with 1M tasks and the rest of benchmarks performed test cases with 10M tasks, both in unlimited goroutines and `ants` pool, and the capacity of this `ants` goroutine-pool was limited to 50K.
+
+- BenchmarkGoroutine-4 represents the benchmarks with unlimited goroutines in golang.
+
+- BenchmarkPoolGroutine-4 represents the benchmarks with a `ants` pool.
+
+The test data above is a basic benchmark and more detailed benchmarks are about to be uploaded later.
+
+### Benchmarks with Pool 
+
+![](https://user-images.githubusercontent.com/7496278/51515499-f187c500-1e4e-11e9-80e5-3df8f94fa70f.png)
+
+In above benchmark picture, the first and second benchmarks performed test cases with 1M tasks and the rest of benchmarks performed test cases with 10M tasks, both in unlimited goroutines and `ants` pool, and the capacity of this `ants` goroutine-pool was limited to 50K.
+
+**As you can see, `ants` can up to 2x faster than goroutines without pool (10M tasks) and it only consumes half the memory comparing with goroutines without pool. (both 1M and 10M tasks)**
+
+### Benchmarks with PoolWithFunc
+
+![](https://user-images.githubusercontent.com/7496278/51515565-1e3bdc80-1e4f-11e9-8a08-452ab91d117e.png)
+
+### Throughput (it is suitable for scenarios where asynchronous tasks are submitted despite of the final results) 
+
+#### 100K tasks
+
+![](https://user-images.githubusercontent.com/7496278/51515590-36abf700-1e4f-11e9-91e4-7bd3dcb5f4a5.png)
+
+#### 1M tasks
+
+![](https://user-images.githubusercontent.com/7496278/51515596-44617c80-1e4f-11e9-89e3-01e19d2979a1.png)
+
+#### 10M tasks
+
+![](https://user-images.githubusercontent.com/7496278/52987732-537c2000-3437-11e9-86a6-177f00d7a1d6.png)
+
+### Performance Summary
+
+![](https://user-images.githubusercontent.com/7496278/52989641-51b65a80-343f-11e9-86c0-e855d97343ea.gif)
+
+**In conclusion, `ants` can up to 2x~6x faster than goroutines without a pool and the memory consumption is reduced by 10 to 20 times.**

--- a/vendor/github.com/panjf2000/ants/README_ZH.md
+++ b/vendor/github.com/panjf2000/ants/README_ZH.md
@@ -1,0 +1,291 @@
+# ants
+<p align="center">
+<img src="https://user-images.githubusercontent.com/7496278/51748488-8efd2600-20e7-11e9-91f5-1c5b466dcca1.jpg"/>
+A goroutine pool for Go
+<br/><br/>
+<a title="Build Status" target="_blank" href="https://travis-ci.com/panjf2000/ants"><img src="https://img.shields.io/travis/com/panjf2000/ants?style=flat-square"></a>
+<a title="Codecov" target="_blank" href="https://codecov.io/gh/panjf2000/ants"><img src="https://img.shields.io/codecov/c/github/panjf2000/ants?style=flat-square"></a>
+<a title="Go Report Card" target="_blank" href="https://goreportcard.com/report/github.com/panjf2000/ants"><img src="https://goreportcard.com/badge/github.com/panjf2000/ants?style=flat-square"></a>
+<a title="Ants on Sourcegraph" target="_blank" href="https://sourcegraph.com/github.com/panjf2000/ants?badge"><img src="https://sourcegraph.com/github.com/panjf2000/ants/-/badge.svg?style=flat-square"></a>
+<br/>
+<a title="" target="_blank" href="https://golangci.com/r/github.com/panjf2000/ants"><img src="https://golangci.com/badges/github.com/panjf2000/ants.svg"></a>
+<a title="Godoc for ants" target="_blank" href="https://godoc.org/github.com/panjf2000/ants"><img src="https://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square"></a>
+<a title="Release" target="_blank" href="https://github.com/panjf2000/ants/releases"><img src="https://img.shields.io/github/release/panjf2000/ants.svg?style=flat-square"></a>
+<a title="License" target="_blank" href="https://opensource.org/licenses/mit-license.php"><img src="https://img.shields.io/aur/license/pac?style=flat-square"></a>
+</p>
+
+[英文](README.md) | [项目博客](https://taohuawu.club/high-performance-implementation-of-goroutine-pool)
+
+`ants`是一个高性能的协程池，实现了对大规模 goroutine 的调度管理、goroutine 复用，允许使用者在开发并发程序的时候限制协程数量，复用资源，达到更高效执行任务的效果。
+
+## 功能：
+
+- 实现了自动调度并发的 goroutine，复用 goroutine
+- 定时清理过期的 goroutine，进一步节省资源
+- 提供了友好的接口：任务提交、获取运行中的协程数量、动态调整协程池大小
+- 优雅处理 panic，防止程序崩溃
+- 资源复用，极大节省内存使用量；在大规模批量并发任务场景下比原生 goroutine 并发具有更高的性能
+
+## 目前测试通过的Golang版本：
+
+- 1.8.x
+- 1.9.x
+- 1.10.x
+- 1.11.x
+- 1.12.x
+
+
+## 安装
+
+``` sh
+go get -u github.com/panjf2000/ants
+```
+
+## 使用
+写 go 并发程序的时候如果程序会启动大量的 goroutine ，势必会消耗大量的系统资源（内存，CPU），通过使用 `ants`，可以实例化一个协程池，复用 goroutine ，节省资源，提升性能：
+
+``` go
+package main
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/panjf2000/ants"
+)
+
+var sum int32
+
+func myFunc(i interface{}) {
+	n := i.(int32)
+	atomic.AddInt32(&sum, n)
+	fmt.Printf("run with %d\n", n)
+}
+
+func demoFunc() {
+	time.Sleep(10 * time.Millisecond)
+	fmt.Println("Hello World!")
+}
+
+func main() {
+	defer ants.Release()
+
+	runTimes := 1000
+
+	// Use the common pool.
+	var wg sync.WaitGroup
+	syncCalculateSum := func() {
+		demoFunc()
+		wg.Done()
+	}
+	for i := 0; i < runTimes; i++ {
+		wg.Add(1)
+		_ = ants.Submit(syncCalculateSum)
+	}
+	wg.Wait()
+	fmt.Printf("running goroutines: %d\n", ants.Running())
+	fmt.Printf("finish all tasks.\n")
+
+	// Use the pool with a method,
+	// set 10 to the capacity of goroutine pool and 1 second for expired duration.
+	p, _ := ants.NewPoolWithFunc(ants.Options{Capacity: 10, PoolFunc: func(i interface{}) {
+		myFunc(i)
+		wg.Done()
+	}})
+	defer p.Release()
+	// Submit tasks one by one.
+	for i := 0; i < runTimes; i++ {
+		wg.Add(1)
+		_ = p.Invoke(int32(i))
+	}
+	wg.Wait()
+	fmt.Printf("running goroutines: %d\n", p.Running())
+	fmt.Printf("finish all tasks, result is %d\n", sum)
+}
+```
+
+## 与 http server 集成
+```go
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"github.com/panjf2000/ants"
+)
+
+type Request struct {
+	Param  []byte
+	Result chan []byte
+}
+
+func main() {
+  pool, _ := ants.NewPoolWithFunc(ants.Options{Capacity:100, PoolFunc:func(payload interface{}) {
+		request, ok := payload.(*Request)
+		if !ok {
+			return
+		}
+		reverseParam := func(s []byte) []byte {
+			for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+				s[i], s[j] = s[j], s[i]
+			}
+			return s
+		}(request.Param)
+
+		request.Result <- reverseParam
+  }})
+	defer pool.Release()
+
+	http.HandleFunc("/reverse", func(w http.ResponseWriter, r *http.Request) {
+		param, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "request error", http.StatusInternalServerError)
+		}
+		defer r.Body.Close()
+
+		request := &Request{Param: param, Result: make(chan []byte)}
+
+		// Throttle the requests traffic with ants pool. This process is asynchronous and
+		// you can receive a result from the channel defined outside.
+		if err := pool.Invoke(request); err != nil {
+			http.Error(w, "throttle limit error", http.StatusInternalServerError)
+		}
+
+		w.Write(<-request.Result)
+	})
+
+	http.ListenAndServe(":8080", nil)
+}
+```
+
+## Pool 配置
+
+```go
+type Options struct {
+	// Capacity of the pool.
+	Capacity int
+
+	// ExpiryDuration set the expired time (second) of every worker.
+	ExpiryDuration time.Duration
+
+	// PreAlloc indicate whether to make memory pre-allocation when initializing Pool.
+	PreAlloc bool
+
+	// Max number of goroutine blocking on pool.Submit.
+	// 0 (default value) means no such limit.
+	MaxBlockingTasks int
+
+	// When Nonblocking is true, Pool.Submit will never be blocked.
+	// ErrPoolOverload will be returned when Pool.Submit cannot be done at once.
+	// When Nonblocking is true, MaxBlockingTasks is inoperative.
+	Nonblocking bool
+
+	// PanicHandler is used to handle panics from each worker goroutine.
+	// if nil, panics will be thrown out again from worker goroutines.
+	PanicHandler func(interface{})
+
+	// poolFunc is the function for processing tasks.
+	PoolFunc func(interface{})
+}
+```
+
+你可以根据自己的需求在`ants.Options`中设置各个配置项的值，然后用它来初始化 goroutine pool.
+
+
+## 自定义池
+`ants`支持实例化使用者自己的一个 Pool ，指定具体的池容量；通过调用 `NewPool` 方法可以实例化一个新的带有指定容量的 Pool ，如下：
+
+``` go
+// Set 10000 the size of goroutine pool
+p, _ := ants.NewPool(ants.Options{Capacity: 10000})
+```
+
+## 任务提交
+
+提交任务通过调用 `ants.Submit(func())`方法：
+```go
+ants.Submit(func(){})
+```
+
+## 动态调整协程池容量
+需要动态调整协程池容量可以通过调用`Tune(int)`：
+
+``` go
+pool.Tune(1000) // Tune its capacity to 1000
+pool.Tune(100000) // Tune its capacity to 100000
+```
+
+该方法是线程安全的。
+
+## 预先分配 goroutine 队列内存
+
+`ants`允许你预先把整个池的容量分配内存， 这个功能可以在某些特定的场景下提高协程池的性能。比如， 有一个场景需要一个超大容量的池，而且每个 goroutine 里面的任务都是耗时任务，这种情况下，预先分配 goroutine 队列内存将会减少 re-slice 时的复制内存损耗。
+
+```go
+// ants will pre-malloc the whole capacity of pool when you invoke this function
+p, _ := ants.NewPool(ants.Options{Capacity: AntsSize, PreAlloc: true})
+```
+
+
+
+## 销毁协程池
+
+```go
+pool.Release()
+```
+
+## Benchmarks
+
+系统参数：
+
+```
+OS: macOS High Sierra
+Processor: 2.7 GHz Intel Core i5
+Memory: 8 GB 1867 MHz DDR3
+
+Go Version: 1.9
+```
+
+
+
+<div align="center"><img src="https://user-images.githubusercontent.com/7496278/51515466-c7ce9e00-1e4e-11e9-89c4-bd3785b3c667.png"/></div>
+上图中的前两个 benchmark 测试结果是基于100w 任务量的条件，剩下的几个是基于 1000w 任务量的测试结果，`ants`的默认池容量是 5w。
+
+- BenchmarkGoroutine-4 代表原生 goroutine
+
+- BenchmarkPoolGroutine-4 代表使用协程池`ants`
+
+### Benchmarks with Pool 
+
+![](https://user-images.githubusercontent.com/7496278/51515499-f187c500-1e4e-11e9-80e5-3df8f94fa70f.png)
+
+**这里为了模拟大规模 goroutine 的场景，两次测试的并发次数分别是 100w 和 1000w，前两个测试分别是执行 100w 个并发任务不使用 Pool 和使用了`ants`的 Goroutine Pool 的性能，后两个则是 1000w 个任务下的表现，可以直观的看出在执行速度和内存使用上，`ants`的 Pool 都占有明显的优势。100w 的任务量，使用`ants`，执行速度与原生 goroutine 相当甚至略快，但只实际使用了不到 5w 个 goroutine 完成了全部任务，且内存消耗仅为原生并发的 40%；而当任务量达到 1000w，优势则更加明显了：用了 70w 左右的 goroutine 完成全部任务，执行速度比原生 goroutine 提高了 100%，且内存消耗依旧保持在不使用 Pool 的 40% 左右。**
+
+### Benchmarks with PoolWithFunc
+
+![](https://user-images.githubusercontent.com/7496278/51515565-1e3bdc80-1e4f-11e9-8a08-452ab91d117e.png)
+
+**因为`PoolWithFunc`这个 Pool 只绑定一个任务函数，也即所有任务都是运行同一个函数，所以相较于`Pool`对原生 goroutine 在执行速度和内存消耗的优势更大，上面的结果可以看出，执行速度可以达到原生 goroutine 的 300%，而内存消耗的优势已经达到了两位数的差距，原生 goroutine 的内存消耗达到了`ants`的35倍且原生 goroutine 的每次执行的内存分配次数也达到了`ants`45倍，1000w 的任务量，`ants`的初始分配容量是 5w，因此它完成了所有的任务依旧只使用了 5w 个 goroutine！事实上，`ants`的 Goroutine Pool 的容量是可以自定义的，也就是说使用者可以根据不同场景对这个参数进行调优直至达到最高性能。**
+
+### 吞吐量测试（适用于那种只管提交异步任务而无须关心结果的场景）
+
+#### 10w 任务量
+
+![](https://user-images.githubusercontent.com/7496278/51515590-36abf700-1e4f-11e9-91e4-7bd3dcb5f4a5.png)
+
+#### 100w 任务量
+
+![](https://user-images.githubusercontent.com/7496278/51515596-44617c80-1e4f-11e9-89e3-01e19d2979a1.png)
+
+#### 1000w 任务量
+
+![](https://user-images.githubusercontent.com/7496278/52987732-537c2000-3437-11e9-86a6-177f00d7a1d6.png)
+
+### 性能小结
+
+![](https://user-images.githubusercontent.com/7496278/52989641-51b65a80-343f-11e9-86c0-e855d97343ea.gif)
+
+**从该 demo 测试吞吐性能对比可以看出，使用`ants`的吞吐性能相较于原生 goroutine 可以保持在 2-6 倍的性能压制，而内存消耗则可以达到 10-20 倍的节省优势。** 

--- a/vendor/github.com/panjf2000/ants/ants.go
+++ b/vendor/github.com/panjf2000/ants/ants.go
@@ -1,0 +1,133 @@
+// MIT License
+
+// Copyright (c) 2018 Andy Pan
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package ants
+
+import (
+	"errors"
+	"math"
+	"runtime"
+	"time"
+)
+
+const (
+	// DEFAULT_ANTS_POOL_SIZE is the default capacity for a default goroutine pool.
+	DEFAULT_ANTS_POOL_SIZE = math.MaxInt32
+
+	// DEFAULT_CLEAN_INTERVAL_TIME is the interval time to clean up goroutines.
+	DEFAULT_CLEAN_INTERVAL_TIME = 1
+
+	// CLOSED represents that the pool is closed.
+	CLOSED = 1
+)
+
+var (
+	// Error types for the Ants API.
+	//---------------------------------------------------------------------------
+
+	// ErrInvalidPoolSize will be returned when setting a negative number as pool capacity.
+	ErrInvalidPoolSize = errors.New("invalid size for pool")
+
+	// ErrLackPoolFunc will be returned when invokers don't provide function for pool.
+	ErrLackPoolFunc = errors.New("must provide function for pool")
+
+	// ErrInvalidPoolExpiry will be returned when setting a negative number as the periodic duration to purge goroutines.
+	ErrInvalidPoolExpiry = errors.New("invalid expiry for pool")
+
+	// ErrPoolClosed will be returned when submitting task to a closed pool.
+	ErrPoolClosed = errors.New("this pool has been closed")
+
+	// ErrPoolOverload will be returned when the pool is full and no workers available.
+	ErrPoolOverload = errors.New("too many goroutines blocked on submit or Nonblocking is set")
+	//---------------------------------------------------------------------------
+
+	// workerChanCap determines whether the channel of a worker should be a buffered channel
+	// to get the best performance. Inspired by fasthttp at https://github.com/valyala/fasthttp/blob/master/workerpool.go#L139
+	workerChanCap = func() int {
+		// Use blocking workerChan if GOMAXPROCS=1.
+		// This immediately switches Serve to WorkerFunc, which results
+		// in higher performance (under go1.5 at least).
+		if runtime.GOMAXPROCS(0) == 1 {
+			return 0
+		}
+
+		// Use non-blocking workerChan if GOMAXPROCS>1,
+		// since otherwise the Serve caller (Acceptor) may lag accepting
+		// new connections if WorkerFunc is CPU-bound.
+		return 1
+	}()
+
+	// Init a instance pool when importing ants.
+	defaultAntsPool, _ = NewPool(Options{Capacity: DEFAULT_ANTS_POOL_SIZE})
+)
+
+type Options struct {
+	// Capacity of the pool.
+	Capacity int
+
+	// ExpiryDuration set the expired time (second) of every worker.
+	ExpiryDuration time.Duration
+
+	// PreAlloc indicate whether to make memory pre-allocation when initializing Pool.
+	PreAlloc bool
+
+	// Max number of goroutine blocking on pool.Submit.
+	// 0 (default value) means no such limit.
+	MaxBlockingTasks int
+
+	// When Nonblocking is true, Pool.Submit will never be blocked.
+	// ErrPoolOverload will be returned when Pool.Submit cannot be done at once.
+	// When Nonblocking is true, MaxBlockingTasks is inoperative.
+	Nonblocking bool
+
+	// PanicHandler is used to handle panics from each worker goroutine.
+	// if nil, panics will be thrown out again from worker goroutines.
+	PanicHandler func(interface{})
+
+	// PoolFunc is the function for processing tasks.
+	PoolFunc func(interface{})
+}
+
+// Submit submits a task to pool.
+func Submit(task func()) error {
+	return defaultAntsPool.Submit(task)
+}
+
+// Running returns the number of the currently running goroutines.
+func Running() int {
+	return defaultAntsPool.Running()
+}
+
+// Cap returns the capacity of this default pool.
+func Cap() int {
+	return defaultAntsPool.Cap()
+}
+
+// Free returns the available goroutines to work.
+func Free() int {
+	return defaultAntsPool.Free()
+}
+
+// Release Closes the default pool.
+func Release() {
+	defaultAntsPool.Release()
+}

--- a/vendor/github.com/panjf2000/ants/go.mod
+++ b/vendor/github.com/panjf2000/ants/go.mod
@@ -1,0 +1,1 @@
+module github.com/panjf2000/ants

--- a/vendor/github.com/panjf2000/ants/pool.go
+++ b/vendor/github.com/panjf2000/ants/pool.go
@@ -1,0 +1,300 @@
+// MIT License
+
+// Copyright (c) 2018 Andy Pan
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package ants
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Pool accept the tasks from client, it limits the total of goroutines to a given number by recycling goroutines.
+type Pool struct {
+	// capacity of the pool.
+	capacity int32
+
+	// running is the number of the currently running goroutines.
+	running int32
+
+	// expiryDuration set the expired time (second) of every worker.
+	expiryDuration time.Duration
+
+	// workers is a slice that store the available workers.
+	workers []*goWorker
+
+	// release is used to notice the pool to closed itself.
+	release int32
+
+	// lock for synchronous operation.
+	lock sync.Mutex
+
+	// cond for waiting to get a idle worker.
+	cond *sync.Cond
+
+	// once makes sure releasing this pool will just be done for one time.
+	once sync.Once
+
+	// workerCache speeds up the obtainment of the an usable worker in function:retrieveWorker.
+	workerCache sync.Pool
+
+	// panicHandler is used to handle panics from each worker goroutine.
+	// if nil, panics will be thrown out again from worker goroutines.
+	panicHandler func(interface{})
+
+	// Max number of goroutine blocking on pool.Submit.
+	// 0 (default value) means no such limit.
+	maxBlockingTasks int32
+
+	// goroutine already been blocked on pool.Submit
+	// protected by pool.lock
+	blockingNum int32
+
+	// When nonblocking is true, Pool.Submit will never be blocked.
+	// ErrPoolOverload will be returned when Pool.Submit cannot be done at once.
+	// When nonblocking is true, MaxBlockingTasks is inoperative.
+	nonblocking bool
+}
+
+// Clear expired workers periodically.
+func (p *Pool) periodicallyPurge() {
+	heartbeat := time.NewTicker(p.expiryDuration)
+	defer heartbeat.Stop()
+
+	var expiredWorkers []*goWorker
+	for range heartbeat.C {
+		if atomic.LoadInt32(&p.release) == CLOSED {
+			break
+		}
+		currentTime := time.Now()
+		p.lock.Lock()
+		idleWorkers := p.workers
+		n := len(idleWorkers)
+		i := 0
+		for i < n && currentTime.Sub(idleWorkers[i].recycleTime) > p.expiryDuration {
+			i++
+		}
+		expiredWorkers = append(expiredWorkers[:0], idleWorkers[:i]...)
+		if i > 0 {
+			m := copy(idleWorkers, idleWorkers[i:])
+			for i = m; i < n; i++ {
+				idleWorkers[i] = nil
+			}
+			p.workers = idleWorkers[:m]
+		}
+		p.lock.Unlock()
+
+		// Notify obsolete workers to stop.
+		// This notification must be outside the p.lock, since w.task
+		// may be blocking and may consume a lot of time if many workers
+		// are located on non-local CPUs.
+		for i, w := range expiredWorkers {
+			w.task <- nil
+			expiredWorkers[i] = nil
+		}
+
+		// There might be a situation that all workers have been cleaned up(no any worker is running)
+		// while some invokers still get stuck in "p.cond.Wait()",
+		// then it ought to wakes all those invokers.
+		if p.Running() == 0 {
+			p.cond.Broadcast()
+		}
+	}
+}
+
+// NewPool generates an instance of ants pool.
+func NewPool(opts Options) (*Pool, error) {
+	if opts.Capacity <= 0 {
+		return nil, ErrInvalidPoolSize
+	}
+
+	if expiry := opts.ExpiryDuration; expiry < 0 {
+		return nil, ErrInvalidPoolExpiry
+	} else if expiry == 0 {
+		opts.ExpiryDuration = time.Duration(DEFAULT_CLEAN_INTERVAL_TIME) * time.Second
+	}
+
+	var p *Pool
+	if opts.PreAlloc {
+		p = &Pool{
+			capacity:         int32(opts.Capacity),
+			expiryDuration:   opts.ExpiryDuration,
+			workers:          make([]*goWorker, 0, opts.Capacity),
+			nonblocking:      opts.Nonblocking,
+			maxBlockingTasks: int32(opts.MaxBlockingTasks),
+			panicHandler:     opts.PanicHandler,
+		}
+	} else {
+		p = &Pool{
+			capacity:         int32(opts.Capacity),
+			expiryDuration:   opts.ExpiryDuration,
+			nonblocking:      opts.Nonblocking,
+			maxBlockingTasks: int32(opts.MaxBlockingTasks),
+			panicHandler:     opts.PanicHandler,
+		}
+	}
+	p.cond = sync.NewCond(&p.lock)
+
+	// Start a goroutine to clean up expired workers periodically.
+	go p.periodicallyPurge()
+
+	return p, nil
+}
+
+//---------------------------------------------------------------------------
+
+// Submit submits a task to this pool.
+func (p *Pool) Submit(task func()) error {
+	if atomic.LoadInt32(&p.release) == CLOSED {
+		return ErrPoolClosed
+	}
+	if w := p.retrieveWorker(); w == nil {
+		return ErrPoolOverload
+	} else {
+		w.task <- task
+	}
+	return nil
+}
+
+// Running returns the number of the currently running goroutines.
+func (p *Pool) Running() int {
+	return int(atomic.LoadInt32(&p.running))
+}
+
+// Free returns the available goroutines to work.
+func (p *Pool) Free() int {
+	return int(atomic.LoadInt32(&p.capacity) - atomic.LoadInt32(&p.running))
+}
+
+// Cap returns the capacity of this pool.
+func (p *Pool) Cap() int {
+	return int(atomic.LoadInt32(&p.capacity))
+}
+
+// Tune changes the capacity of this pool.
+func (p *Pool) Tune(size int) {
+	if p.Cap() == size {
+		return
+	}
+	atomic.StoreInt32(&p.capacity, int32(size))
+	diff := p.Running() - size
+	for i := 0; i < diff; i++ {
+		p.retrieveWorker().task <- nil
+	}
+}
+
+// Release Closes this pool.
+func (p *Pool) Release() {
+	p.once.Do(func() {
+		atomic.StoreInt32(&p.release, 1)
+		p.lock.Lock()
+		idleWorkers := p.workers
+		for i, w := range idleWorkers {
+			w.task <- nil
+			idleWorkers[i] = nil
+		}
+		p.workers = nil
+		p.lock.Unlock()
+	})
+}
+
+//---------------------------------------------------------------------------
+
+// incRunning increases the number of the currently running goroutines.
+func (p *Pool) incRunning() {
+	atomic.AddInt32(&p.running, 1)
+}
+
+// decRunning decreases the number of the currently running goroutines.
+func (p *Pool) decRunning() {
+	atomic.AddInt32(&p.running, -1)
+}
+
+// retrieveWorker returns a available worker to run the tasks.
+func (p *Pool) retrieveWorker() *goWorker {
+	var w *goWorker
+	spawnWorker := func() {
+		if cacheWorker := p.workerCache.Get(); cacheWorker != nil {
+			w = cacheWorker.(*goWorker)
+		} else {
+			w = &goWorker{
+				pool: p,
+				task: make(chan func(), workerChanCap),
+			}
+		}
+		w.run()
+	}
+
+	p.lock.Lock()
+	idleWorkers := p.workers
+	n := len(idleWorkers) - 1
+	if n >= 0 {
+		w = idleWorkers[n]
+		idleWorkers[n] = nil
+		p.workers = idleWorkers[:n]
+		p.lock.Unlock()
+	} else if p.Running() < p.Cap() {
+		p.lock.Unlock()
+		spawnWorker()
+	} else {
+		if p.nonblocking {
+			p.lock.Unlock()
+			return nil
+		}
+	Reentry:
+		if p.maxBlockingTasks != 0 && p.blockingNum >= p.maxBlockingTasks {
+			p.lock.Unlock()
+			return nil
+		}
+		p.blockingNum++
+		p.cond.Wait()
+		p.blockingNum--
+		if p.Running() == 0 {
+			p.lock.Unlock()
+			spawnWorker()
+			return w
+		}
+		l := len(p.workers) - 1
+		if l < 0 {
+			goto Reentry
+		}
+		w = p.workers[l]
+		p.workers[l] = nil
+		p.workers = p.workers[:l]
+		p.lock.Unlock()
+	}
+	return w
+}
+
+// revertWorker puts a worker back into free pool, recycling the goroutines.
+func (p *Pool) revertWorker(worker *goWorker) bool {
+	if atomic.LoadInt32(&p.release) == CLOSED {
+		return false
+	}
+	worker.recycleTime = time.Now()
+	p.lock.Lock()
+	p.workers = append(p.workers, worker)
+	// Notify the invoker stuck in 'retrieveWorker()' of there is an available worker in the worker queue.
+	p.cond.Signal()
+	p.lock.Unlock()
+	return true
+}

--- a/vendor/github.com/panjf2000/ants/pool_func.go
+++ b/vendor/github.com/panjf2000/ants/pool_func.go
@@ -1,0 +1,306 @@
+// MIT License
+
+// Copyright (c) 2018 Andy Pan
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package ants
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// PoolWithFunc accept the tasks from client, it limits the total of goroutines to a given number by recycling goroutines.
+type PoolWithFunc struct {
+	// capacity of the pool.
+	capacity int32
+
+	// running is the number of the currently running goroutines.
+	running int32
+
+	// expiryDuration set the expired time (second) of every worker.
+	expiryDuration time.Duration
+
+	// workers is a slice that store the available workers.
+	workers []*goWorkerWithFunc
+
+	// release is used to notice the pool to closed itself.
+	release int32
+
+	// lock for synchronous operation.
+	lock sync.Mutex
+
+	// cond for waiting to get a idle worker.
+	cond *sync.Cond
+
+	// poolFunc is the function for processing tasks.
+	poolFunc func(interface{})
+
+	// once makes sure releasing this pool will just be done for one time.
+	once sync.Once
+
+	// workerCache speeds up the obtainment of the an usable worker in function:retrieveWorker.
+	workerCache sync.Pool
+
+	// panicHandler is used to handle panics from each worker goroutine.
+	// if nil, panics will be thrown out again from worker goroutines.
+	panicHandler func(interface{})
+
+	// Max number of goroutine blocking on pool.Submit.
+	// 0 (default value) means no such limit.
+	maxBlockingTasks int32
+
+	// goroutine already been blocked on pool.Submit
+	// protected by pool.lock
+	blockingNum int32
+
+	// When nonblocking is true, Pool.Submit will never be blocked.
+	// ErrPoolOverload will be returned when Pool.Submit cannot be done at once.
+	// When nonblocking is true, MaxBlockingTasks is inoperative.
+	nonblocking bool
+}
+
+// Clear expired workers periodically.
+func (p *PoolWithFunc) periodicallyPurge() {
+	heartbeat := time.NewTicker(p.expiryDuration)
+	defer heartbeat.Stop()
+
+	var expiredWorkers []*goWorkerWithFunc
+	for range heartbeat.C {
+		if atomic.LoadInt32(&p.release) == CLOSED {
+			break
+		}
+		currentTime := time.Now()
+		p.lock.Lock()
+		idleWorkers := p.workers
+		n := len(idleWorkers)
+		i := 0
+		for i < n && currentTime.Sub(idleWorkers[i].recycleTime) > p.expiryDuration {
+			i++
+		}
+		expiredWorkers = append(expiredWorkers[:0], idleWorkers[:i]...)
+		if i > 0 {
+			m := copy(idleWorkers, idleWorkers[i:])
+			for i = m; i < n; i++ {
+				idleWorkers[i] = nil
+			}
+			p.workers = idleWorkers[:m]
+		}
+		p.lock.Unlock()
+
+		// Notify obsolete workers to stop.
+		// This notification must be outside the p.lock, since w.task
+		// may be blocking and may consume a lot of time if many workers
+		// are located on non-local CPUs.
+		for i, w := range expiredWorkers {
+			w.args <- nil
+			expiredWorkers[i] = nil
+		}
+
+		// There might be a situation that all workers have been cleaned up(no any worker is running)
+		// while some invokers still get stuck in "p.cond.Wait()",
+		// then it ought to wakes all those invokers.
+		if p.Running() == 0 {
+			p.cond.Broadcast()
+		}
+	}
+}
+
+// NewPoolWithFunc generates an instance of ants pool with a specific function.
+func NewPoolWithFunc(opts Options) (*PoolWithFunc, error) {
+	if opts.Capacity <= 0 {
+		return nil, ErrInvalidPoolSize
+	}
+
+	if opts.PoolFunc == nil {
+		return nil, ErrLackPoolFunc
+	}
+
+	if expiry := opts.ExpiryDuration; expiry < 0 {
+		return nil, ErrInvalidPoolExpiry
+	} else if expiry == 0 {
+		opts.ExpiryDuration = time.Duration(DEFAULT_CLEAN_INTERVAL_TIME) * time.Second
+	}
+
+	var p *PoolWithFunc
+	if opts.PreAlloc {
+		p = &PoolWithFunc{
+			capacity:         int32(opts.Capacity),
+			expiryDuration:   opts.ExpiryDuration,
+			poolFunc:         opts.PoolFunc,
+			workers:          make([]*goWorkerWithFunc, 0, opts.Capacity),
+			nonblocking:      opts.Nonblocking,
+			maxBlockingTasks: int32(opts.MaxBlockingTasks),
+			panicHandler:     opts.PanicHandler,
+		}
+	} else {
+		p = &PoolWithFunc{
+			capacity:         int32(opts.Capacity),
+			expiryDuration:   opts.ExpiryDuration,
+			poolFunc:         opts.PoolFunc,
+			nonblocking:      opts.Nonblocking,
+			maxBlockingTasks: int32(opts.MaxBlockingTasks),
+			panicHandler:     opts.PanicHandler,
+		}
+	}
+	p.cond = sync.NewCond(&p.lock)
+	go p.periodicallyPurge()
+	return p, nil
+}
+
+//---------------------------------------------------------------------------
+
+// Invoke submits a task to pool.
+func (p *PoolWithFunc) Invoke(args interface{}) error {
+	if atomic.LoadInt32(&p.release) == CLOSED {
+		return ErrPoolClosed
+	}
+	if w := p.retrieveWorker(); w == nil {
+		return ErrPoolOverload
+	} else {
+		w.args <- args
+	}
+	return nil
+}
+
+// Running returns the number of the currently running goroutines.
+func (p *PoolWithFunc) Running() int {
+	return int(atomic.LoadInt32(&p.running))
+}
+
+// Free returns a available goroutines to work.
+func (p *PoolWithFunc) Free() int {
+	return int(atomic.LoadInt32(&p.capacity) - atomic.LoadInt32(&p.running))
+}
+
+// Cap returns the capacity of this pool.
+func (p *PoolWithFunc) Cap() int {
+	return int(atomic.LoadInt32(&p.capacity))
+}
+
+// Tune change the capacity of this pool.
+func (p *PoolWithFunc) Tune(size int) {
+	if p.Cap() == size {
+		return
+	}
+	atomic.StoreInt32(&p.capacity, int32(size))
+	diff := p.Running() - size
+	for i := 0; i < diff; i++ {
+		p.retrieveWorker().args <- nil
+	}
+}
+
+// Release Closed this pool.
+func (p *PoolWithFunc) Release() {
+	p.once.Do(func() {
+		atomic.StoreInt32(&p.release, 1)
+		p.lock.Lock()
+		idleWorkers := p.workers
+		for i, w := range idleWorkers {
+			w.args <- nil
+			idleWorkers[i] = nil
+		}
+		p.workers = nil
+		p.lock.Unlock()
+	})
+}
+
+//---------------------------------------------------------------------------
+
+// incRunning increases the number of the currently running goroutines.
+func (p *PoolWithFunc) incRunning() {
+	atomic.AddInt32(&p.running, 1)
+}
+
+// decRunning decreases the number of the currently running goroutines.
+func (p *PoolWithFunc) decRunning() {
+	atomic.AddInt32(&p.running, -1)
+}
+
+// retrieveWorker returns a available worker to run the tasks.
+func (p *PoolWithFunc) retrieveWorker() *goWorkerWithFunc {
+	var w *goWorkerWithFunc
+	spawnWorker := func() {
+		if cacheWorker := p.workerCache.Get(); cacheWorker != nil {
+			w = cacheWorker.(*goWorkerWithFunc)
+		} else {
+			w = &goWorkerWithFunc{
+				pool: p,
+				args: make(chan interface{}, workerChanCap),
+			}
+		}
+		w.run()
+	}
+
+	p.lock.Lock()
+	idleWorkers := p.workers
+	n := len(idleWorkers) - 1
+	if n >= 0 {
+		w = idleWorkers[n]
+		idleWorkers[n] = nil
+		p.workers = idleWorkers[:n]
+		p.lock.Unlock()
+	} else if p.Running() < p.Cap() {
+		p.lock.Unlock()
+		spawnWorker()
+	} else {
+		if p.nonblocking {
+			p.lock.Unlock()
+			return nil
+		}
+	Reentry:
+		if p.maxBlockingTasks != 0 && p.blockingNum >= p.maxBlockingTasks {
+			p.lock.Unlock()
+			return nil
+		}
+		p.blockingNum++
+		p.cond.Wait()
+		p.blockingNum--
+		if p.Running() == 0 {
+			p.lock.Unlock()
+			spawnWorker()
+			return w
+		}
+		l := len(p.workers) - 1
+		if l < 0 {
+			goto Reentry
+		}
+		w = p.workers[l]
+		p.workers[l] = nil
+		p.workers = p.workers[:l]
+		p.lock.Unlock()
+	}
+	return w
+}
+
+// revertWorker puts a worker back into free pool, recycling the goroutines.
+func (p *PoolWithFunc) revertWorker(worker *goWorkerWithFunc) bool {
+	if atomic.LoadInt32(&p.release) == CLOSED {
+		return false
+	}
+	worker.recycleTime = time.Now()
+	p.lock.Lock()
+	p.workers = append(p.workers, worker)
+	// Notify the invoker stuck in 'retrieveWorker()' of there is an available worker in the worker queue.
+	p.cond.Signal()
+	p.lock.Unlock()
+	return true
+}

--- a/vendor/github.com/panjf2000/ants/worker.go
+++ b/vendor/github.com/panjf2000/ants/worker.go
@@ -1,0 +1,77 @@
+// MIT License
+
+// Copyright (c) 2018 Andy Pan
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package ants
+
+import (
+	"log"
+	"runtime"
+	"time"
+)
+
+// goWorker is the actual executor who runs the tasks,
+// it starts a goroutine that accepts tasks and
+// performs function calls.
+type goWorker struct {
+	// pool who owns this worker.
+	pool *Pool
+
+	// task is a job should be done.
+	task chan func()
+
+	// recycleTime will be update when putting a worker back into queue.
+	recycleTime time.Time
+}
+
+// run starts a goroutine to repeat the process
+// that performs the function calls.
+func (w *goWorker) run() {
+	w.pool.incRunning()
+	go func() {
+		defer func() {
+			if p := recover(); p != nil {
+				w.pool.decRunning()
+				w.pool.workerCache.Put(w)
+				if w.pool.panicHandler != nil {
+					w.pool.panicHandler(p)
+				} else {
+					log.Printf("worker exits from a panic: %v\n", p)
+					var buf [4096]byte
+					n := runtime.Stack(buf[:], false)
+					log.Printf("worker exits from panic: %s\n", string(buf[:n]))
+				}
+			}
+		}()
+
+		for f := range w.task {
+			if f == nil {
+				w.pool.decRunning()
+				w.pool.workerCache.Put(w)
+				return
+			}
+			f()
+			if ok := w.pool.revertWorker(w); !ok {
+				break
+			}
+		}
+	}()
+}

--- a/vendor/github.com/panjf2000/ants/worker_func.go
+++ b/vendor/github.com/panjf2000/ants/worker_func.go
@@ -1,0 +1,77 @@
+// MIT License
+
+// Copyright (c) 2018 Andy Pan
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package ants
+
+import (
+	"log"
+	"runtime"
+	"time"
+)
+
+// goWorkerWithFunc is the actual executor who runs the tasks,
+// it starts a goroutine that accepts tasks and
+// performs function calls.
+type goWorkerWithFunc struct {
+	// pool who owns this worker.
+	pool *PoolWithFunc
+
+	// args is a job should be done.
+	args chan interface{}
+
+	// recycleTime will be update when putting a worker back into queue.
+	recycleTime time.Time
+}
+
+// run starts a goroutine to repeat the process
+// that performs the function calls.
+func (w *goWorkerWithFunc) run() {
+	w.pool.incRunning()
+	go func() {
+		defer func() {
+			if p := recover(); p != nil {
+				w.pool.decRunning()
+				w.pool.workerCache.Put(w)
+				if w.pool.panicHandler != nil {
+					w.pool.panicHandler(p)
+				} else {
+					log.Printf("worker with func exits from a panic: %v\n", p)
+					var buf [4096]byte
+					n := runtime.Stack(buf[:], false)
+					log.Printf("worker with func exits from panic: %s\n", string(buf[:n]))
+				}
+			}
+		}()
+
+		for args := range w.args {
+			if args == nil {
+				w.pool.decRunning()
+				w.pool.workerCache.Put(w)
+				return
+			}
+			w.pool.poolFunc(args)
+			if ok := w.pool.revertWorker(w); !ok {
+				break
+			}
+		}
+	}()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -44,6 +44,8 @@ github.com/mattn/go-isatty
 github.com/mitchellh/go-homedir
 # github.com/mitchellh/mapstructure v1.1.2
 github.com/mitchellh/mapstructure
+# github.com/panjf2000/ants v0.0.0-20190820151255-b60dfa8c16b0
+github.com/panjf2000/ants
 # github.com/pelletier/go-toml v1.2.0
 github.com/pelletier/go-toml
 # github.com/pkg/errors v0.8.1


### PR DESCRIPTION
Previously the internal autoscaler iterated through the scaling
policies and launched a go routine to run the autoscaling check
process. There were no limits on the number of routines which
could lead to overloading on the Nomad API.

This change introduces a goroutine pool in order to limit the
number of concurrent scaling threads. The number of threads is
configurable via the CLI, with a default of 3. When all threads
are in use, the iteration will block until additional work
can be consumed. There is a timelimit of the execution, currently
set to 60's which we may want to make configurable in the future.

closes #23 