### PR TITLE
Add simple UI to provide visual overview of scaling events.

### DIFF
--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -23,6 +23,8 @@ const (
 	configKeyPolicyEngineStrictCheckingEnabled = "policy-engine-strict-checking-enabled"
 	configKeyStorageBackendConsulEnabled       = "storage-consul-enabled"
 	configKeyStorageBackendConsulPath          = "storage-consul-path"
+
+	configKeyUI = "ui"
 )
 
 type Config struct {
@@ -34,6 +36,7 @@ type Config struct {
 	StrictPolicyChecking         bool
 	InternalAutoScaler           bool
 	ConsulStorageBackend         bool
+	UI                           bool
 	InternalAutoScalerEvalPeriod int
 	InternalAutoScalerNumThreads int
 }
@@ -48,7 +51,8 @@ func (c *Config) MarshalZerologObject(e *zerolog.Event) {
 		Int(configKeyAutoscalerEvaluationInterval, c.InternalAutoScalerEvalPeriod).
 		Int(configKeyAutoscalerThreadNumber, c.InternalAutoScalerNumThreads).
 		Bool(configKeyStorageBackendConsulEnabled, c.ConsulStorageBackend).
-		Str(configKeyStorageBackendConsulPath, c.ConsulStorageBackendPath)
+		Str(configKeyStorageBackendConsulPath, c.ConsulStorageBackendPath).
+		Bool(configKeyUI, c.UI)
 }
 
 func GetConfig() Config {
@@ -63,6 +67,7 @@ func GetConfig() Config {
 		InternalAutoScalerNumThreads: viper.GetInt(configKeyAutoscalerThreadNumber),
 		ConsulStorageBackend:         viper.GetBool(configKeyStorageBackendConsulEnabled),
 		ConsulStorageBackendPath:     viper.GetString(configKeyStorageBackendConsulPath),
+		UI:                           viper.GetBool(configKeyUI),
 	}
 }
 
@@ -195,6 +200,19 @@ func RegisterConfig(cmd *cobra.Command) {
 		)
 
 		flags.String(longOpt, defaultValue, description)
+		_ = viper.BindPFlag(key, flags.Lookup(longOpt))
+		viper.SetDefault(key, defaultValue)
+	}
+
+	{
+		const (
+			key          = configKeyUI
+			longOpt      = "ui"
+			defaultValue = false
+			description  = "Run the Sherpa user interface"
+		)
+
+		flags.Bool(longOpt, defaultValue, description)
 		_ = viper.BindPFlag(key, flags.Lookup(longOpt))
 		viper.SetDefault(key, defaultValue)
 	}

--- a/pkg/config/server/server_test.go
+++ b/pkg/config/server/server_test.go
@@ -20,4 +20,5 @@ func Test_ServerConfig(t *testing.T) {
 	assert.Equal(t, false, cfg.InternalAutoScaler)
 	assert.Equal(t, configKeyStorageBackendConsulPathDefault, cfg.ConsulStorageBackendPath)
 	assert.Equal(t, configKeyAutoscalerThreadNumberDefault, cfg.InternalAutoScalerNumThreads)
+	assert.Equal(t, false, cfg.UI)
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -11,22 +11,25 @@ type Config struct {
 }
 
 const (
-	routeSystemHealthName          = "GetSystemHealth"
-	routeSystemHealthPattern       = "/v1/system/health"
-	routeSystemInfoName            = "GetSystemInfo"
-	routeSystemInfoPattern         = "/v1/system/info"
-	routeScaleOutJobGroupName      = "ScaleOutJobGroup"
-	routeScaleOutJobGroupPattern   = "/v1/scale/out/{job_id}/{group}"
-	routeScaleInJobGroupName       = "ScaleInJobGroup"
-	routeScaleInJobGroupPattern    = "/v1/scale/in/{job_id}/{group}"
-	routeGetJobScalingPoliciesName = "GetJobScalingPolicies"
+	routeUIRedirectName    = "UIRedirect"
+	routeUIRedirectPattern = "/"
+	routeUIName            = "UI"
+	routeUIPattern         = "/ui"
 
 	routeGetScalingStatusPattern = "/v1/scale/status"
 	routeGetScalingStatusName    = "GetScalingStatus"
+	routeGetScalingInfoPattern   = "/v1/scale/status/{id}"
+	routeGetScalingInfoName      = "GetScalingInfo"
 
-	routeGetScalingInfoPattern = "/v1/scale/status/{id}"
-	routeGetScalingInfoName    = "GetScalingInfo"
-
+	routeSystemHealthName                   = "GetSystemHealth"
+	routeSystemHealthPattern                = "/v1/system/health"
+	routeSystemInfoName                     = "GetSystemInfo"
+	routeSystemInfoPattern                  = "/v1/system/info"
+	routeScaleOutJobGroupName               = "ScaleOutJobGroup"
+	routeScaleOutJobGroupPattern            = "/v1/scale/out/{job_id}/{group}"
+	routeScaleInJobGroupName                = "ScaleInJobGroup"
+	routeScaleInJobGroupPattern             = "/v1/scale/in/{job_id}/{group}"
+	routeGetJobScalingPoliciesName          = "GetJobScalingPolicies"
 	routeGetJobScalingPoliciesPattern       = "/v1/policies"
 	routeGetJobScalingPolicyName            = "GetJobScalingPolicy"
 	routeGetJobScalingPolicyPattern         = "/v1/policy/{job_id}"

--- a/pkg/server/endpoints/v1/ui.go
+++ b/pkg/server/endpoints/v1/ui.go
@@ -1,0 +1,125 @@
+package v1
+
+import (
+	"html/template"
+	"net/http"
+
+	"github.com/jrasell/sherpa/pkg/build"
+)
+
+type UIServer struct {
+	build buildInfo
+}
+
+// buildInfo is the Sherpa server build information used to display on the UI.
+type buildInfo struct {
+	Version string
+}
+
+func NewUIServer() *UIServer {
+	return &UIServer{
+		build: buildInfo{
+			Version: build.Version,
+		},
+	}
+}
+
+func (s *UIServer) Redirect(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, "/ui", http.StatusSeeOther)
+}
+
+func (s *UIServer) Get(w http.ResponseWriter, r *http.Request) {
+	_ = tmplScaleEvent.ExecuteTemplate(w, "scaling-events", s.build)
+}
+
+var tmplScaleEvent = template.Must(template.New("scaling-events").Parse(`
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Sherpa</title>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+
+    <style type="text/css">
+        td.tags { display: none; }
+        .footer { padding-top: 10px; }
+        .logo { height: 32px; margin: 0 auto; display: block; }
+
+        @media (min-width: 78em) {
+            td.tags{ display: table-cell; }
+        }
+    </style>
+</head>
+<body>
+
+<ul id="overrides" class="dropdown-content"></ul>
+
+<nav class="top-nav teal accent-4">
+    <div class="container">
+        <div class="nav-wrapper">
+            <a href="/ui" class="brand-logo">Sherpa</a>
+            <ul id="nav-mobile" class="right hide-on-med-and-down">
+				<li><a href="https://github.com/jrasell/sherpa/releases">{{.Version}}</a></li>
+				<li><a href="https://cloud.docker.com/u/jrasell/repository/docker/jrasell/sherpa">DockerHub</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+
+<div class="container">
+    <div class="section">
+        <table class="events highlight"></table>
+    </div>
+</div>
+
+<script>
+    $(function(){
+        var params={};window.location.search.replace(/[?&]+([^=&]+)=([^&]*)/gi,function(str,key,value){params[key] = value;});
+        function renderEvents(events) {
+            var $table = $('table.events');
+            var thead = '<thead><tr>';
+            thead += '<th>ID</th>';
+            thead += '<th>Job:Group</th>';
+            thead += '<th>Status</th>';
+            thead += '<th>Time</th>';
+            thead += '</tr></thead>';
+            var $tbody = $('<tbody />');
+            for (var [id, job] of Object.entries(events)) {
+                for (var [jbname, event] of Object.entries(job)) {
+                    var $tr = $('<tr />');
+                    $tr.append($('<td />').text(id));
+                    $tr.append($('<td />').text(jbname));
+                    $tr.append($('<td />').text(event.Status));
+                    $tr.append($('<td />').text(timeConverter(event.Time)));
+                    $tr.appendTo($tbody);
+                }
+            }
+
+            $table.empty().append($(thead)).append($tbody);
+        }
+
+        function timeConverter(ts){
+            var a = new Date(ts/1000000);
+            var year = a.getUTCFullYear();
+            var month = a.getUTCMonth();
+            var date = a.getUTCDate();
+            var hour = a.getUTCHours();
+            var min = a.getUTCMinutes();
+            var sec = a.getUTCSeconds();
+            var ms = a.getUTCMilliseconds();
+            return year + "-" + month + "-" + date + " " + hour + ':' + min + ':' + sec + "." + ms + " +0000 UTC"
+        }		
+
+        $.get("/v1/scale/status", function(data) {
+            renderEvents(data);
+        });
+    })
+</script>
+
+</body>
+</html>
+`))

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -6,6 +6,7 @@ import (
 	policyV1 "github.com/jrasell/sherpa/pkg/policy/v1"
 	watcher2 "github.com/jrasell/sherpa/pkg/policy/watcher"
 	scaleV1 "github.com/jrasell/sherpa/pkg/scale/v1"
+	v1 "github.com/jrasell/sherpa/pkg/server/endpoints/v1"
 	"github.com/jrasell/sherpa/pkg/server/router"
 	systemV1 "github.com/jrasell/sherpa/pkg/system/v1"
 )
@@ -14,38 +15,74 @@ type routes struct {
 	System *systemV1.System
 	Policy *policyV1.Policy
 	Scale  *scaleV1.Scale
+	UI     *v1.UIServer
 }
 
 func (h *HTTPServer) setupRoutes() *router.RouteTable {
 	h.logger.Debug().Msg("setting up HTTP server routes")
 
-	// Setup our route servers with their required configuration.
-	h.routes.System = systemV1.NewSystemServer(h.logger, h.nomad, h.cfg.Server, h.telemetry)
-	h.routes.Scale = scaleV1.NewScaleServer(h.logger, h.cfg.Server.StrictPolicyChecking, h.policyBackend, h.stateBackend, h.nomad)
-	h.routes.Policy = policyV1.NewPolicyServer(h.logger, h.policyBackend)
+	var r router.RouteTable
 
-	systemRoutes := router.Routes{
-		router.Route{
-			Name:    routeSystemHealthName,
-			Method:  http.MethodGet,
-			Pattern: routeSystemHealthPattern,
-			Handler: h.routes.System.GetHealth,
-		},
-		router.Route{
-			Name:    routeSystemInfoName,
-			Method:  http.MethodGet,
-			Pattern: routeSystemInfoPattern,
-			Handler: h.routes.System.GetInfo,
-		},
-		router.Route{
-			Name:    routeGetMetricsName,
-			Method:  http.MethodGet,
-			Pattern: routeGetMetricsPattern,
-			Handler: h.routes.System.GetMetrics,
-		},
+	// Setup the scaling routes.
+	scaleRoutes := h.setupScaleRoutes()
+	r = append(r, scaleRoutes)
+
+	// Setup the system routes.
+	systemRoutes := h.setupSystemRoutes()
+	r = append(r, systemRoutes)
+
+	// Setup the base policy routes.
+	policyRoutes := h.setupPolicyRoutes()
+	r = append(r, policyRoutes)
+
+	// Setup the UI routes if it is enabled.
+	if h.cfg.Server.UI {
+		uiRoutes := h.setupUIRoutes()
+		r = append(r, uiRoutes)
 	}
 
-	scaleRoutes := router.Routes{
+	// TODO (jrasell) move this out of the route setup. I don't know why this is here.
+	if h.cfg.Server.NomadMetaPolicyEngine {
+		watcher := watcher2.NewMetaWatcher(h.logger, h.nomad, h.policyBackend)
+		go watcher.Run()
+	}
+
+	// Setup the policy engine API route if it is enabled.
+	if h.cfg.Server.APIPolicyEngine {
+		apiPolicyRoutes := h.setupAPIPolicyRoutes()
+		r = append(r, apiPolicyRoutes)
+	}
+
+	return &r
+}
+
+func (h *HTTPServer) setupUIRoutes() []router.Route {
+	h.logger.Debug().Msg("setting up server UI routes")
+
+	h.routes.UI = v1.NewUIServer()
+
+	return router.Routes{
+		router.Route{
+			Name:    routeUIName,
+			Method:  http.MethodGet,
+			Pattern: routeUIPattern,
+			Handler: h.routes.UI.Get,
+		},
+		router.Route{
+			Name:    routeUIRedirectName,
+			Method:  http.MethodGet,
+			Pattern: routeUIRedirectPattern,
+			Handler: h.routes.UI.Redirect,
+		},
+	}
+}
+
+func (h *HTTPServer) setupScaleRoutes() []router.Route {
+	h.logger.Debug().Msg("setting up server scale routes")
+
+	h.routes.Scale = scaleV1.NewScaleServer(h.logger, h.cfg.Server.StrictPolicyChecking, h.policyBackend, h.stateBackend, h.nomad)
+
+	return router.Routes{
 		router.Route{
 			Name:    routeScaleOutJobGroupName,
 			Method:  http.MethodPut,
@@ -72,8 +109,41 @@ func (h *HTTPServer) setupRoutes() *router.RouteTable {
 			Handler: h.routes.Scale.StatusInfo,
 		},
 	}
+}
 
-	policyRoutes := router.Routes{
+func (h *HTTPServer) setupSystemRoutes() []router.Route {
+	h.logger.Debug().Msg("setting up server system routes")
+
+	h.routes.System = systemV1.NewSystemServer(h.logger, h.nomad, h.cfg.Server, h.telemetry)
+
+	return router.Routes{
+		router.Route{
+			Name:    routeSystemHealthName,
+			Method:  http.MethodGet,
+			Pattern: routeSystemHealthPattern,
+			Handler: h.routes.System.GetHealth,
+		},
+		router.Route{
+			Name:    routeSystemInfoName,
+			Method:  http.MethodGet,
+			Pattern: routeSystemInfoPattern,
+			Handler: h.routes.System.GetInfo,
+		},
+		router.Route{
+			Name:    routeGetMetricsName,
+			Method:  http.MethodGet,
+			Pattern: routeGetMetricsPattern,
+			Handler: h.routes.System.GetMetrics,
+		},
+	}
+}
+
+func (h *HTTPServer) setupPolicyRoutes() []router.Route {
+	h.logger.Debug().Msg("setting up server policy routes")
+
+	h.routes.Policy = policyV1.NewPolicyServer(h.logger, h.policyBackend)
+
+	return router.Routes{
 		router.Route{
 			Name:    routeGetJobScalingPoliciesName,
 			Method:  http.MethodGet,
@@ -93,43 +163,35 @@ func (h *HTTPServer) setupRoutes() *router.RouteTable {
 			Handler: h.routes.Policy.GetJobGroupPolicy,
 		},
 	}
+}
 
-	if h.cfg.Server.NomadMetaPolicyEngine {
-		watcher := watcher2.NewMetaWatcher(h.logger, h.nomad, h.policyBackend)
-		go watcher.Run()
+func (h *HTTPServer) setupAPIPolicyRoutes() []router.Route {
+	h.logger.Debug().Msg("setting up server API policy engine routes")
+
+	return router.Routes{
+		router.Route{
+			Name:    routePostJobScalingPolicyName,
+			Method:  http.MethodPost,
+			Pattern: routePutJobScalingPolicyPattern,
+			Handler: h.routes.Policy.PutJobPolicy,
+		},
+		router.Route{
+			Name:    routePostJobGroupScalingPolicyName,
+			Method:  http.MethodPost,
+			Pattern: routePutJobGroupScalingPolicyPattern,
+			Handler: h.routes.Policy.PutJobGroupPolicy,
+		},
+		router.Route{
+			Name:    routeDeleteJobGroupScalingPolicyName,
+			Method:  http.MethodDelete,
+			Pattern: routeDeleteJobGroupScalingPolicyPattern,
+			Handler: h.routes.Policy.DeleteJobGroupPolicy,
+		},
+		router.Route{
+			Name:    routeDeleteJobScalingPolicyName,
+			Method:  http.MethodDelete,
+			Pattern: routeDeleteJobScalingPolicyPattern,
+			Handler: h.routes.Policy.DeleteJobPolicy,
+		},
 	}
-
-	if h.cfg.Server.APIPolicyEngine {
-		h.logger.Info().Msg("starting Sherpa API policy engine")
-
-		apiPolicyEngineRoutes := router.Routes{
-			router.Route{
-				Name:    routePostJobScalingPolicyName,
-				Method:  http.MethodPost,
-				Pattern: routePutJobScalingPolicyPattern,
-				Handler: h.routes.Policy.PutJobPolicy,
-			},
-			router.Route{
-				Name:    routePostJobGroupScalingPolicyName,
-				Method:  http.MethodPost,
-				Pattern: routePutJobGroupScalingPolicyPattern,
-				Handler: h.routes.Policy.PutJobGroupPolicy,
-			},
-			router.Route{
-				Name:    routeDeleteJobGroupScalingPolicyName,
-				Method:  http.MethodDelete,
-				Pattern: routeDeleteJobGroupScalingPolicyPattern,
-				Handler: h.routes.Policy.DeleteJobGroupPolicy,
-			},
-			router.Route{
-				Name:    routeDeleteJobScalingPolicyName,
-				Method:  http.MethodDelete,
-				Pattern: routeDeleteJobScalingPolicyPattern,
-				Handler: h.routes.Policy.DeleteJobPolicy,
-			},
-		}
-		return &router.RouteTable{systemRoutes, scaleRoutes, policyRoutes, apiPolicyEngineRoutes}
-	}
-
-	return &router.RouteTable{systemRoutes, scaleRoutes, policyRoutes}
 }


### PR DESCRIPTION
It is sometimes easier for operators to get a quick overview of
system information by glancing at a UI. This commit therefore
introduces a UI which can be enabled via a CLI flag.

The UI provides an overview of scaling events in a table format
headed by links to useful Sherpa resources. When the UI is enabled
a call to / will be redirected to /ui where the UI endpoint handler
is running.

Closes #31