### PR TITLE
Ensure go mod is not enabled when install makefile tools.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,8 +2,8 @@ default: lint test build
 
 tools: ## Install the tools used to test and build
 	@echo "==> Installing build tools"
-	go get github.com/ahmetb/govvv
-	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+	GO111MODULE=off go get -u github.com/ahmetb/govvv
+	GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 build: ## Build Sherpa for development purposes
 	@echo "==> Running $@..."


### PR DESCRIPTION
Running the makefile tools target with go mod enabled breaks their
install meaning following makefile commands all fail for various
reasons. This change enforces go mod is off just for these
commands to ensure smooth makefile running.