### PR TITLE
Autoscaler log to debug when it suggests a group should be scaled.

### DIFF
--- a/pkg/autoscale/autoscale.go
+++ b/pkg/autoscale/autoscale.go
@@ -77,7 +77,7 @@ func (a *AutoScale) autoscaleJob(jobID string, policies map[string]*policy.Group
 			req := &scale.GroupReq{Direction: scalingDir, Count: count, GroupName: group, GroupScalingPolicy: pol}
 			scaleReq = append(scaleReq, req)
 
-			a.logger.Info().
+			a.logger.Debug().
 				Str("job", jobID).
 				Object("scaling-req", req).
 				Msg("added group scaling request")


### PR DESCRIPTION
When the autoscaler determines a group can be scaled based on its
resource consumption the log line should be at debug rather than
info. This is because the scaler then needs to process the request
which may not be allowed, meaning this addition is advisory and
can clutter logs when a group is running on very low resource use.
