### PR TITLE
Update system info to reference more generic storage backend.

### DIFF
--- a/cmd/system/info/command.go
+++ b/cmd/system/info/command.go
@@ -43,7 +43,7 @@ func runInfo(_ *cobra.Command, _ []string) {
 	var out []string
 	out = append(out, fmt.Sprintf("%s|%s", "Nomad Address", info.NomadAddress))
 	out = append(out, fmt.Sprintf("%s|%s", "Policy Engine", info.PolicyEngine))
-	out = append(out, fmt.Sprintf("%s|%s", "Policy Storage Backend", info.PolicyStorageBackend))
+	out = append(out, fmt.Sprintf("%s|%s", "Storage Backend", info.StorageBackend))
 	out = append(out, fmt.Sprintf("%s|%v", "Internal AutoScaling Engine", info.InternalAutoScalingEngine))
 	out = append(out, fmt.Sprintf("%s|%v", "Strict Policy Checking", info.StrictPolicyChecking))
 

--- a/docs/api/system.md
+++ b/docs/api/system.md
@@ -47,7 +47,7 @@ $ curl \
   "InternalAutoScalingEngine": true,
   "NomadAddress": "http://localhost:4646",
   "PolicyEngine": "Sherpa API",
-  "PolicyStorageBackend": "Consul",
+  "StorageBackend": "Consul",
   "StrictPolicyChecking": false
 }
 ```

--- a/pkg/api/system.go
+++ b/pkg/api/system.go
@@ -13,7 +13,7 @@ type HealthResp struct {
 type InfoResp struct {
 	NomadAddress              string
 	PolicyEngine              string
-	PolicyStorageBackend      string
+	StorageBackend            string
 	InternalAutoScalingEngine bool
 	StrictPolicyChecking      bool
 }

--- a/pkg/system/v1/system.go
+++ b/pkg/system/v1/system.go
@@ -15,12 +15,12 @@ const (
 	headerKeyContentType       = "Content-Type"
 	headerValueContentTypeJSON = "application/json; charset=utf-8"
 
-	defaultHealthResp          = "{\"status\":\"ok\"}"
-	defaultAPIPolicyResp       = "Sherpa API"
-	defaultMetaPolicyResp      = "Nomad Job Group Meta"
-	defaultDisabledPolicyResp  = "Disabled"
-	defaultPolicyBackend       = "In Memory"
-	defaultPolicyBackendConsul = "Consul"
+	defaultHealthResp           = "{\"status\":\"ok\"}"
+	defaultAPIPolicyResp        = "Sherpa API"
+	defaultMetaPolicyResp       = "Nomad Job Group Meta"
+	defaultDisabledPolicyResp   = "Disabled"
+	defaultStorageBackend       = "In Memory"
+	defaultStorageBackendConsul = "Consul"
 )
 
 type System struct {
@@ -33,7 +33,7 @@ type System struct {
 type SystemInfoResp struct {
 	NomadAddress              string
 	PolicyEngine              string
-	PolicyStorageBackend      string
+	StorageBackend            string
 	InternalAutoScalingEngine bool
 	StrictPolicyChecking      bool
 }
@@ -57,11 +57,11 @@ func (h *System) GetInfo(w http.ResponseWriter, r *http.Request) {
 		StrictPolicyChecking:      h.server.StrictPolicyChecking,
 		InternalAutoScalingEngine: h.server.InternalAutoScaler,
 		PolicyEngine:              defaultDisabledPolicyResp,
-		PolicyStorageBackend:      defaultPolicyBackend,
+		StorageBackend:            defaultStorageBackend,
 	}
 
 	if h.server.ConsulStorageBackend {
-		resp.PolicyStorageBackend = defaultPolicyBackendConsul
+		resp.StorageBackend = defaultStorageBackendConsul
 	}
 
 	if h.server.APIPolicyEngine {

--- a/pkg/system/v1/system_test.go
+++ b/pkg/system/v1/system_test.go
@@ -30,22 +30,22 @@ func TestSystem_GetInfo(t *testing.T) {
 		{
 			systemServerConfig: &server.Config{APIPolicyEngine: true, ConsulStorageBackend: true},
 			expectedRespCode:   200,
-			expectedRespBody:   "{\"NomadAddress\":\"http://127.0.0.1:4646\",\"PolicyEngine\":\"Sherpa API\",\"PolicyStorageBackend\":\"Consul\",\"InternalAutoScalingEngine\":false,\"StrictPolicyChecking\":false}",
+			expectedRespBody:   "{\"NomadAddress\":\"http://127.0.0.1:4646\",\"PolicyEngine\":\"Sherpa API\",\"StorageBackend\":\"Consul\",\"InternalAutoScalingEngine\":false,\"StrictPolicyChecking\":false}",
 		},
 		{
 			systemServerConfig: &server.Config{NomadMetaPolicyEngine: true},
 			expectedRespCode:   200,
-			expectedRespBody:   "{\"NomadAddress\":\"http://127.0.0.1:4646\",\"PolicyEngine\":\"Nomad Job Group Meta\",\"PolicyStorageBackend\":\"In Memory\",\"InternalAutoScalingEngine\":false,\"StrictPolicyChecking\":false}",
+			expectedRespBody:   "{\"NomadAddress\":\"http://127.0.0.1:4646\",\"PolicyEngine\":\"Nomad Job Group Meta\",\"StorageBackend\":\"In Memory\",\"InternalAutoScalingEngine\":false,\"StrictPolicyChecking\":false}",
 		},
 		{
 			systemServerConfig: &server.Config{APIPolicyEngine: true, InternalAutoScaler: true},
 			expectedRespCode:   200,
-			expectedRespBody:   "{\"NomadAddress\":\"http://127.0.0.1:4646\",\"PolicyEngine\":\"Sherpa API\",\"PolicyStorageBackend\":\"In Memory\",\"InternalAutoScalingEngine\":true,\"StrictPolicyChecking\":false}",
+			expectedRespBody:   "{\"NomadAddress\":\"http://127.0.0.1:4646\",\"PolicyEngine\":\"Sherpa API\",\"StorageBackend\":\"In Memory\",\"InternalAutoScalingEngine\":true,\"StrictPolicyChecking\":false}",
 		},
 		{
 			systemServerConfig: &server.Config{},
 			expectedRespCode:   200,
-			expectedRespBody:   "{\"NomadAddress\":\"http://127.0.0.1:4646\",\"PolicyEngine\":\"Disabled\",\"PolicyStorageBackend\":\"In Memory\",\"InternalAutoScalingEngine\":false,\"StrictPolicyChecking\":false}",
+			expectedRespBody:   "{\"NomadAddress\":\"http://127.0.0.1:4646\",\"PolicyEngine\":\"Disabled\",\"StorageBackend\":\"In Memory\",\"InternalAutoScalingEngine\":false,\"StrictPolicyChecking\":false}",
 		},
 	}
 


### PR DESCRIPTION
The Sherpa storage backend is now a more generic storage backend rather than just for policies. The Sherpa internals are therefore updated to match this.