### PR TITLE
test: establish acceptance tests for policy API

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,6 +14,10 @@ test: ## Run the Sherpa test suite with coverage
 	@go test ./... -cover -v -tags -race \
 		"$(BUILDTAGS)" $(shell go list ./... | grep -v vendor)
 
+acctest: ## Run the Sherpa acceptance test suite
+	@echo "==> Running $@..."
+	@SHERPA_ACC=1 go test ./test -count 1 -v -mod vendor
+
 release: ## Trigger the release build script
 	@echo "==> Running $@..."
 	@goreleaser --rm-dist

--- a/test/acctest/acctest.go
+++ b/test/acctest/acctest.go
@@ -1,0 +1,159 @@
+// Package acctest provides a small testing framework for Sherpa
+package acctest
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	nomad "github.com/hashicorp/nomad/api"
+	"github.com/jrasell/sherpa/pkg/api"
+	clientCfg "github.com/jrasell/sherpa/pkg/config/client"
+)
+
+// TestCase is a single test of Sherpa
+type TestCase struct {
+	// Steps are ran in order stopping on failure
+	Steps []TestStep
+
+	// CleanupFunc is called at the end of the TestCase if set
+	CleanupFunc TestStateFunc
+}
+
+// TestStep is a single step within a TestCase
+type TestStep struct {
+	// Runner is used to execute the step
+	Runner TestStateFunc
+
+	// ExpectErr allows Runner to fail, use CheckErr to confirm error is correct
+	ExpectErr bool
+
+	// CheckErr is called if Runner fails and ExpectErr is true
+	CheckErr func(error) bool
+}
+
+// TestState is the configuration for the TestCase
+type TestState struct {
+	// JobName is a concatenation of "sherpa" and the test function name
+	JobName string
+
+	Sherpa *api.Client
+	Nomad  *nomad.Client
+}
+
+// TestStateFunc provides a TestStep with access to the test state
+type TestStateFunc func(*TestState) error
+
+// ComposeTestStateFunc combines multiple TestStateFuncs into one
+func ComposeTestStateFunc(f ...TestStateFunc) TestStateFunc {
+	return func(s *TestState) error {
+		for _, fun := range f {
+			if err := fun(s); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+// Test executes a single TestCase
+//
+// Tests will be skipped if SHERPA_ACC is empty
+func Test(t *testing.T, c TestCase) {
+	if os.Getenv("SHERPA_ACC") == "" {
+		t.SkipNow()
+	}
+
+	if len(c.Steps) < 1 {
+		t.Fatal("must have at least one test step")
+	}
+
+	sherpa, err := newSherpaClient()
+	if err != nil {
+		t.Fatalf("failed to create Sherpa client: %s", err)
+	}
+
+	nomad, err := newNomadClient()
+	if err != nil {
+		t.Fatalf("failed to create Nomad client: %s", err)
+	}
+
+	state := &TestState{
+		JobName: fmt.Sprintf("sherpa-%s", t.Name()),
+		Sherpa:  sherpa,
+		Nomad:   nomad,
+	}
+
+	for i, step := range c.Steps {
+		stepNum := i + 1
+
+		if step.Runner == nil {
+			t.Errorf("step %d/%d does not have a Runner", stepNum, len(c.Steps))
+			break
+		}
+
+		err = step.Runner(state)
+		if err != nil {
+			if !step.ExpectErr {
+				t.Errorf("step %d/%d failed: %s", stepNum, len(c.Steps), err)
+				break
+			}
+
+			if step.CheckErr != nil {
+				ok := step.CheckErr(err)
+				if !ok {
+					t.Errorf("step %d/%d CheckErr failed: %s", stepNum, len(c.Steps), err)
+					break
+				}
+			}
+		}
+	}
+
+	if c.CleanupFunc != nil {
+		err = c.CleanupFunc(state)
+		if err != nil {
+			t.Errorf("cleanup failed: %s", err)
+		}
+	}
+}
+
+// newNomadClient creates a Nomad API client configrable by NOMAD_
+// env variables or returns an error if Nomad is in an unhealthy state
+func newNomadClient() (*nomad.Client, error) {
+	c, err := nomad.NewClient(nomad.DefaultConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.Agent().Health()
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.Server.Ok || !resp.Client.Ok {
+		return nil, fmt.Errorf("agent unhealthy")
+	}
+
+	return c, nil
+}
+
+// newNomadClient creates a Sherpa API client
+func newSherpaClient() (*api.Client, error) {
+	cfg := clientCfg.GetConfig()
+	c, err := api.NewClient(api.DefaultConfig(&cfg))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.System().Health()
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Status != "ok" {
+		return nil, fmt.Errorf("Sherpa agent unhealthy, status: %s", resp.Status)
+	}
+
+	return c, nil
+}

--- a/test/acctest/helpers.go
+++ b/test/acctest/helpers.go
@@ -1,0 +1,63 @@
+package acctest
+
+import (
+	"fmt"
+)
+
+// CleanupPurgeJob is a cleanup func to purge the TestCase job from Nomad
+func CleanupPurgeJob(s *TestState) error {
+	_, _, err := s.Nomad.Jobs().Deregister(s.JobName, true, nil)
+	// TODO: wait for action to complete
+	return err
+}
+
+// CleanupSherpaPolicy is a CleanupFunc to remove a single job policy
+func CleanupSherpaPolicy(s *TestState) error {
+	return s.Sherpa.Policies().DeleteJobPolicy(s.JobName)
+}
+
+// CheckErrEqual is a CheckErr func to test if an error message is as expected
+func CheckErrEqual(expected string) func(error) bool {
+	return func(err error) bool {
+		return expected == err.Error()
+	}
+}
+
+// CheckDeploymentStatus is a TestStateFunc to check if the latest deployment of
+// the TestCase job in Nomad matches the desired status
+func CheckDeploymentStatus(status string) TestStateFunc {
+	return func(s *TestState) error {
+		deploy, _, err := s.Nomad.Jobs().LatestDeployment(s.JobName, nil)
+		if err != nil {
+			return err
+		}
+
+		if deploy.Status != status {
+			return fmt.Errorf("deployment %s is in status '%s', expected '%s'", deploy.ID, deploy.Status, status)
+		}
+
+		return nil
+	}
+}
+
+// CheckTaskGroupCount is a TestStateFunc to check a TaskGroup count matches the expected count
+func CheckTaskGroupCount(groupName string, count int) TestStateFunc {
+	return func(s *TestState) error {
+		job, _, err := s.Nomad.Jobs().Info(s.JobName, nil)
+		if err != nil {
+			return err
+		}
+
+		for _, group := range job.TaskGroups {
+			if groupName == *group.Name {
+				if *group.Count == count {
+					return nil
+				}
+
+				return fmt.Errorf("task group %s count is %d, expected %d", groupName, *group.Count, count)
+			}
+		}
+
+		return fmt.Errorf("unable to find task group %s", groupName)
+	}
+}

--- a/test/policy_test.go
+++ b/test/policy_test.go
@@ -1,0 +1,331 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jrasell/sherpa/pkg/api"
+	"github.com/jrasell/sherpa/test/acctest"
+)
+
+func TestPolicy_list(t *testing.T) {
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: func(s *acctest.TestState) error {
+					policies, err := s.Sherpa.Policies().List()
+					if err != nil {
+						return err
+					}
+					p := *policies
+
+					if _, ok := p[s.JobName]; ok {
+						return fmt.Errorf("expected policy %s to not exist", s.JobName)
+					}
+
+					return nil
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy := &api.JobGroupPolicy{
+						Enabled:  true,
+						MaxCount: 5,
+					}
+					return s.Sherpa.Policies().WriteJobGroupPolicy(s.JobName, "group", policy)
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policies, err := s.Sherpa.Policies().List()
+					if err != nil {
+						return err
+					}
+					p := *policies
+
+					if _, ok := p[s.JobName]; !ok {
+						return fmt.Errorf("expected policy %s to exist", s.JobName)
+					}
+
+					return nil
+				},
+			},
+		},
+		CleanupFunc: acctest.CleanupSherpaPolicy,
+	})
+}
+
+func TestPolicy_readJob(t *testing.T) {
+	groupName := "group"
+
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: func(s *acctest.TestState) error {
+					_, err := s.Sherpa.Policies().ReadJobPolicy(s.JobName)
+					return err
+				},
+				ExpectErr: true,
+				CheckErr:  acctest.CheckErrEqual("unexpected response code 404: 404 page not found"),
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy := &api.JobGroupPolicy{
+						Enabled:  true,
+						MaxCount: 5,
+					}
+					return s.Sherpa.Policies().WriteJobGroupPolicy(s.JobName, groupName, policy)
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policies, err := s.Sherpa.Policies().ReadJobPolicy(s.JobName)
+					if err != nil {
+						return err
+					}
+					p := *policies
+
+					if _, ok := p[groupName]; !ok {
+						return fmt.Errorf("expected policy %s/%s to exist", s.JobName, groupName)
+					}
+
+					return nil
+				},
+			},
+		},
+		CleanupFunc: acctest.CleanupSherpaPolicy,
+	})
+}
+
+func TestPolicy_readJobGroup(t *testing.T) {
+	groupName := "group"
+
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: func(s *acctest.TestState) error {
+					_, err := s.Sherpa.Policies().ReadJobGroupPolicy(s.JobName, groupName)
+					return err
+				},
+				ExpectErr: true,
+				CheckErr:  acctest.CheckErrEqual("unexpected response code 404: 404 page not found"),
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy := &api.JobGroupPolicy{
+						Enabled:  true,
+						MaxCount: 5,
+					}
+					return s.Sherpa.Policies().WriteJobGroupPolicy(s.JobName, groupName, policy)
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy, err := s.Sherpa.Policies().ReadJobGroupPolicy(s.JobName, groupName)
+					if err != nil {
+						return err
+					}
+
+					if policy.MaxCount != 5 {
+						return fmt.Errorf("expected policy %s/%s to match the MaxCount", s.JobName, groupName)
+					}
+
+					return nil
+				},
+			},
+		},
+		CleanupFunc: acctest.CleanupSherpaPolicy,
+	})
+}
+
+func TestPolicy_write(t *testing.T) {
+	groupName := "group"
+
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: func(s *acctest.TestState) error {
+					_, err := s.Sherpa.Policies().ReadJobGroupPolicy(s.JobName, groupName)
+					return err
+				},
+				ExpectErr: true,
+				CheckErr:  acctest.CheckErrEqual("unexpected response code 404: 404 page not found"),
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy := &api.JobGroupPolicy{
+						Enabled:  true,
+						MaxCount: 5,
+					}
+					return s.Sherpa.Policies().WriteJobGroupPolicy(s.JobName, groupName, policy)
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy, err := s.Sherpa.Policies().ReadJobGroupPolicy(s.JobName, groupName)
+					if err != nil {
+						return err
+					}
+
+					if policy.MaxCount != 5 {
+						return fmt.Errorf("expected policy %s/%s to match the MaxCount", s.JobName, groupName)
+					}
+
+					return nil
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy := &api.JobGroupPolicy{
+						Enabled:  true,
+						MaxCount: 6,
+					}
+					return s.Sherpa.Policies().WriteJobGroupPolicy(s.JobName, groupName, policy)
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy, err := s.Sherpa.Policies().ReadJobGroupPolicy(s.JobName, groupName)
+					if err != nil {
+						return err
+					}
+
+					if policy.MaxCount != 6 {
+						return fmt.Errorf("expected policy %s/%s to match the MaxCount", s.JobName, groupName)
+					}
+
+					return nil
+				},
+			},
+		},
+		CleanupFunc: acctest.CleanupSherpaPolicy,
+	})
+}
+
+func TestPolicy_deleteJobPolicy(t *testing.T) {
+	groupName := "group"
+
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: func(s *acctest.TestState) error {
+					_, err := s.Sherpa.Policies().ReadJobPolicy(s.JobName)
+					return err
+				},
+				ExpectErr: true,
+				CheckErr:  acctest.CheckErrEqual("unexpected response code 404: 404 page not found"),
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy := &api.JobGroupPolicy{
+						Enabled:  true,
+						MaxCount: 5,
+					}
+					return s.Sherpa.Policies().WriteJobGroupPolicy(s.JobName, groupName, policy)
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy, err := s.Sherpa.Policies().ReadJobGroupPolicy(s.JobName, groupName)
+					if err != nil {
+						return err
+					}
+
+					if policy.MaxCount != 5 {
+						return fmt.Errorf("expected policy %s/%s to match the MaxCount", s.JobName, groupName)
+					}
+
+					return nil
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					return s.Sherpa.Policies().DeleteJobPolicy(s.JobName)
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					_, err := s.Sherpa.Policies().ReadJobPolicy(s.JobName)
+					return err
+				},
+				ExpectErr: true,
+				CheckErr:  acctest.CheckErrEqual("unexpected response code 404: 404 page not found"),
+			},
+		},
+		CleanupFunc: acctest.CleanupSherpaPolicy,
+	})
+}
+
+func TestPolicy_deleteJobGroupPolicy(t *testing.T) {
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: func(s *acctest.TestState) error {
+					_, err := s.Sherpa.Policies().ReadJobPolicy(s.JobName)
+					return err
+				},
+				ExpectErr: true,
+				CheckErr:  acctest.CheckErrEqual("unexpected response code 404: 404 page not found"),
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy := map[string]*api.JobGroupPolicy{
+						"group1": &api.JobGroupPolicy{
+							Enabled:  true,
+							MaxCount: 5,
+						},
+						"group2": &api.JobGroupPolicy{
+							Enabled:  true,
+							MaxCount: 10,
+						},
+					}
+					return s.Sherpa.Policies().WriteJobPolicy(s.JobName, &policy)
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy, err := s.Sherpa.Policies().ReadJobPolicy(s.JobName)
+					if err != nil {
+						return err
+					}
+					policyMap := *policy
+
+					if p, ok := policyMap["group1"]; !ok || p.MaxCount != 5 {
+						return fmt.Errorf("expected policy %s/%s to exist and match the MaxCount", s.JobName, "group1")
+					}
+
+					if p, ok := policyMap["group2"]; !ok || p.MaxCount != 10 {
+						return fmt.Errorf("expected policy %s/%s to exist and match the MaxCount", s.JobName, "group2")
+					}
+
+					return nil
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					return s.Sherpa.Policies().DeleteJobGroupPolicy(s.JobName, "group1")
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy, err := s.Sherpa.Policies().ReadJobPolicy(s.JobName)
+					if err != nil {
+						return err
+					}
+					policyMap := *policy
+
+					if _, ok := policyMap["group1"]; ok {
+						return fmt.Errorf("expected policy %s/%s to not exist", s.JobName, "group1")
+					}
+
+					if p, ok := policyMap["group2"]; !ok || p.MaxCount != 10 {
+						return fmt.Errorf("expected policy %s/%s to exist and match the MaxCount", s.JobName, "group2")
+					}
+
+					return nil
+				},
+			},
+		},
+		CleanupFunc: acctest.CleanupSherpaPolicy,
+	})
+}


### PR DESCRIPTION
Basic tests for the policy API.

The make rule `acctest` runs the suite with `count 1` to disable the Go test cache.

Currently requires a running Nomad, Sherpa and optional Consul server.