### PR TITLE
Do not scale a job group when it is in deployment.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878
+	github.com/davecgh/go-spew v1.1.1
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/gorilla/mux v1.7.1
 	github.com/hashicorp/consul/api v1.1.0

--- a/pkg/scale/consts.go
+++ b/pkg/scale/consts.go
@@ -12,6 +12,18 @@ type Scale interface {
 	// Trigger performs scaling of 1 or more job groups which belong to the same job.
 	Trigger(string, []*GroupReq, state.Source) (*ScalingResponse, int, error)
 
+	// GetDeploymentChannel is used to return the channel where updates to Nomad deployments should
+	// be sent.
+	GetDeploymentChannel() chan interface{}
+
+	// RunDeploymentUpdateHandler is used to trigger the long running process which handles
+	// messages sent to the deployment update channel.
+	RunDeploymentUpdateHandler()
+
+	// JobGroupIsDeploying checks internal references to identify if the queried job group is
+	// currently in deployment.
+	JobGroupIsDeploying(job, group string) bool
+
 	checkJobGroupExists(*api.Job, string) *api.TaskGroup
 
 	getNewGroupCount(*api.TaskGroup, *GroupReq) int

--- a/pkg/scale/deployments.go
+++ b/pkg/scale/deployments.go
@@ -1,0 +1,71 @@
+package scale
+
+import (
+	"github.com/hashicorp/nomad/api"
+)
+
+// deploymentsKey is a composite key used for storing in-progress Nomad deployments.
+type deploymentsKey struct {
+	job, group string
+}
+
+// GetDeploymentChannel will return the channel where deployment updates should be sent.
+func (s *Scaler) GetDeploymentChannel() chan interface{} {
+	return s.deploymentUpdateChan
+}
+
+// JobGroupIsDeploying returns a boolean to indicate where or not the specified job and group is
+// currently in deployment.
+func (s *Scaler) JobGroupIsDeploying(job, group string) bool {
+	s.deploymentsLock.RLock()
+	_, ok := s.deployments[deploymentsKey{job: job, group: group}]
+	s.deploymentsLock.RUnlock()
+	return ok
+}
+
+// RunDeploymentUpdateHandler is used to handle updates and shutdowns when monitoring Nomad job
+// deployments.
+func (s *Scaler) RunDeploymentUpdateHandler() {
+	s.logger.Info().Msg("starting scaler deployment update handler")
+
+	for {
+		select {
+		case <-s.shutdownChan:
+			return
+		case msg := <-s.deploymentUpdateChan:
+			go s.handleDeploymentMessage(msg)
+		}
+	}
+}
+
+func (s *Scaler) handleDeploymentMessage(msg interface{}) {
+	deployment, ok := msg.(*api.Deployment)
+	if !ok {
+		s.logger.Error().Msg("received unexpected deployment update message type")
+		return
+	}
+	s.logger.Debug().
+		Str("status", deployment.Status).
+		Str("job", deployment.JobID).
+		Msg("received deployment update message to handle")
+
+	s.deploymentsLock.Lock()
+	defer s.deploymentsLock.Unlock()
+
+	switch deployment.Status {
+	case "running":
+		// If the deployment is running, then we need to ensure that this is correctly tracked in
+		// the scaler.
+		for tg := range deployment.TaskGroups {
+			s.deployments[deploymentsKey{job: deployment.JobID, group: tg}] = nil
+		}
+
+	default:
+		// The default is used to catch paused, cancelled, failed, and successful deployments.
+		// These result in the internal tracking of the deployment to be removed, indicating that
+		// the job group is not in deployment and can therefore be scaled.
+		for tg := range deployment.TaskGroups {
+			delete(s.deployments, deploymentsKey{job: deployment.JobID, group: tg})
+		}
+	}
+}

--- a/pkg/scale/deployments_test.go
+++ b/pkg/scale/deployments_test.go
@@ -1,0 +1,51 @@
+package scale
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScaler_JobGroupIsDeploying(t *testing.T) {
+	testCases := []struct {
+		storedMap      map[deploymentsKey]interface{}
+		inputJob       string
+		inputGroup     string
+		expectedResult bool
+		name           string
+	}{
+		{
+			storedMap:      generateStoredMap(),
+			inputJob:       "test-job-1",
+			inputGroup:     "test-group-1",
+			expectedResult: true,
+			name:           "job group within stored map",
+		},
+		{
+			storedMap:      generateStoredMap(),
+			inputJob:       "test-job-2",
+			inputGroup:     "test-group-2",
+			expectedResult: false,
+			name:           "job group not within stored map",
+		},
+		{
+			storedMap:      generateStoredMap(),
+			inputJob:       "test-job-1",
+			inputGroup:     "test-group-2",
+			expectedResult: false,
+			name:           "job exists but group not within stored map",
+		},
+	}
+
+	for _, tc := range testCases {
+		s := Scaler{deployments: tc.storedMap}
+		actualResult := s.JobGroupIsDeploying(tc.inputJob, tc.inputGroup)
+		assert.Equal(t, tc.expectedResult, actualResult, tc.name)
+	}
+}
+
+func generateStoredMap() map[deploymentsKey]interface{} {
+	m := make(map[deploymentsKey]interface{})
+	m[deploymentsKey{job: "test-job-1", group: "test-group-1"}] = nil
+	return m
+}

--- a/pkg/scale/scale.go
+++ b/pkg/scale/scale.go
@@ -3,6 +3,7 @@ package scale
 import (
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/jrasell/sherpa/pkg/state"
@@ -18,14 +19,22 @@ type Scaler struct {
 	nomadClient *api.Client
 	state       scale.Backend
 	strict      bool
+
+	deployments          map[deploymentsKey]interface{}
+	deploymentsLock      sync.RWMutex
+	deploymentUpdateChan chan interface{}
+
+	shutdownChan chan interface{}
 }
 
 func NewScaler(c *api.Client, l zerolog.Logger, state scale.Backend, strictChecking bool) Scale {
 	return &Scaler{
-		logger:      l,
-		nomadClient: c,
-		state:       state,
-		strict:      strictChecking,
+		logger:               l,
+		nomadClient:          c,
+		state:                state,
+		strict:               strictChecking,
+		deployments:          make(map[deploymentsKey]interface{}),
+		deploymentUpdateChan: make(chan interface{}),
 	}
 }
 

--- a/pkg/scale/v1/consts.go
+++ b/pkg/scale/v1/consts.go
@@ -19,4 +19,5 @@ const (
 var (
 	errInternalScaleOutNoPolicy = errors.New("scale out forbidden, no scaling policy found")
 	errInternalScaleInNoPolicy  = errors.New("scale in forbidden, no scaling policy found")
+	errJobGroupInDeployment     = errors.New("scale forbidden, job group currently deploying")
 )

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -80,7 +80,12 @@ func (h *HTTPServer) setupUIRoutes() []router.Route {
 func (h *HTTPServer) setupScaleRoutes() []router.Route {
 	h.logger.Debug().Msg("setting up server scale routes")
 
-	h.routes.Scale = scaleV1.NewScaleServer(h.logger, h.cfg.Server.StrictPolicyChecking, h.policyBackend, h.stateBackend, h.nomad)
+	h.routes.Scale = scaleV1.NewScaleServer(h.cfg.Server.StrictPolicyChecking, &scaleV1.ScaleConfig{
+		Logger: h.logger,
+		Policy: h.policyBackend,
+		Scale:  h.scaleBackend,
+		State:  h.stateBackend,
+	})
 
 	return router.Routes{
 		router.Route{

--- a/pkg/watcher/deployment/deployment.go
+++ b/pkg/watcher/deployment/deployment.go
@@ -1,0 +1,76 @@
+package deployment
+
+import (
+	"time"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/jrasell/sherpa/pkg/watcher"
+	"github.com/rs/zerolog"
+)
+
+type Watcher struct {
+	logger          zerolog.Logger
+	nomad           *api.Client
+	lastChangeIndex uint64
+}
+
+func New(logger zerolog.Logger, nomad *api.Client) watcher.Watcher {
+	return &Watcher{
+		logger: logger,
+		nomad:  nomad,
+	}
+}
+
+func (w *Watcher) Run(updateChan chan interface{}) {
+	w.logger.Info().Msg("starting Sherpa Nomad deployment watcher")
+
+	var maxFound uint64
+
+	q := &api.QueryOptions{WaitTime: 5 * time.Minute, WaitIndex: 1}
+
+	for {
+
+		deployments, meta, err := w.nomad.Deployments().List(q)
+		if err != nil {
+			w.logger.Error().Err(err).Msg("failed to call Nomad API for deployment listing")
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		if !watcher.IndexHasChange(meta.LastIndex, q.WaitIndex) {
+			w.logger.Debug().Msg("deployment watcher last index has not changed")
+			continue
+		}
+		w.logger.Debug().
+			Uint64("old", q.WaitIndex).
+			Uint64("new", meta.LastIndex).
+			Msg("deployment watcher last index has changed")
+
+		// Iterate over all the returned deployments.
+		for i := range deployments {
+
+			// If the change index on the deployment is not newer than the previously recorded last
+			// index we should continue to the next deployment. It is important here to use the
+			// lastChangeIndex from the watcher as we want to process all deployments which have
+			// updated past this index.
+			if !watcher.IndexHasChange(deployments[i].ModifyIndex, w.lastChangeIndex) {
+				continue
+			}
+
+			w.logger.Debug().
+				Uint64("old", w.lastChangeIndex).
+				Uint64("new", deployments[i].ModifyIndex).
+				Str("deployment", deployments[i].ID).
+				Msg("deployment modify index has changed is greater than last recorded")
+
+			maxFound = watcher.MaxFound(deployments[i].ModifyIndex, maxFound)
+			updateChan <- deployments[i]
+		}
+
+		// Update the Nomad API wait index to start long polling from the correct point and update
+		// our recorded lastChangeIndex so we have the correct point to use during the next API
+		// return.
+		q.WaitIndex = meta.LastIndex
+		w.lastChangeIndex = maxFound
+	}
+}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -1,0 +1,28 @@
+package watcher
+
+// Watcher is the interface to satisfy when creating a watcher to run blocking queries on an API
+// and process updates as required.
+type Watcher interface {
+
+	// Run is used to run the watcher loop. The input channel should be the channel where objects
+	// are sent to be acted upon when they are determined to be new.
+	Run(updateChan chan interface{})
+}
+
+// IndexHasChange is used to check whether a returned blocking query has an updated index, compared
+// to a tracked value.
+func IndexHasChange(new, old uint64) bool {
+	if new <= old {
+		return false
+	}
+	return true
+}
+
+// MaxFound is used to determine which value passed is the greatest. This is used to track the most
+// recently found highest index value.
+func MaxFound(new, old uint64) uint64 {
+	if new <= old {
+		return old
+	}
+	return new
+}

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -1,0 +1,70 @@
+package watcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_IndexHasChange(t *testing.T) {
+	testCases := []struct {
+		newValue       uint64
+		oldValue       uint64
+		expectedReturn bool
+	}{
+		{
+			newValue:       13,
+			oldValue:       7,
+			expectedReturn: true,
+		},
+		{
+			newValue:       13696,
+			oldValue:       13696,
+			expectedReturn: false,
+		},
+		{
+			newValue:       7,
+			oldValue:       13,
+			expectedReturn: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		res := IndexHasChange(tc.newValue, tc.oldValue)
+		assert.Equal(t, tc.expectedReturn, res)
+	}
+}
+
+func Test_MaxFound(t *testing.T) {
+	testCases := []struct {
+		newValue       uint64
+		oldValue       uint64
+		expectedReturn uint64
+	}{
+		{
+			newValue:       13,
+			oldValue:       7,
+			expectedReturn: 13,
+		},
+		{
+			newValue:       13696,
+			oldValue:       13696,
+			expectedReturn: 13696,
+		},
+		{
+			newValue:       7,
+			oldValue:       13,
+			expectedReturn: 13,
+		},
+		{
+			newValue:       1,
+			oldValue:       0,
+			expectedReturn: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		res := MaxFound(tc.newValue, tc.oldValue)
+		assert.Equal(t, tc.expectedReturn, res)
+	}
+}


### PR DESCRIPTION
When a job group is going through a Nomad deployment, it is
preferable not to trigger a scaling action. This is because with a
basic deployment in Nomad, performing a scaling register will
cancel the currently running deployment. This can therefore cause
un-expected results.

In order to track deployments, a blocking query is used on the
Nomad API. Updates are then processed and stored internally for
quick lookup. This reduces the load on the Nomad API over calling
it to check every job group when a scaling action is requested. It
does add complexity.

The deployment state is not written to the storage backend, nor is
it leader protected. Nomad itself is the state store for this info
and new servers can quickly and easily update their internal state
to ensure consistent results. This reduces load on the store and
means faster lookup times.

Closes #44