### PR TITLE
Policy meta watcher should start index at 1, not 0.

### DIFF
--- a/pkg/policy/watcher/watcher.go
+++ b/pkg/policy/watcher/watcher.go
@@ -28,7 +28,7 @@ func (m *MetaWatcher) Run() {
 
 	var maxFound uint64
 
-	q := &api.QueryOptions{WaitTime: 5 * time.Minute}
+	q := &api.QueryOptions{WaitTime: 5 * time.Minute, WaitIndex: 1}
 
 	for {
 


### PR DESCRIPTION
Ref: https://github.com/hashicorp/nomad/issues/6403