### PR TITLE
Fix incorrect response code and msg when scaling breaks thresholds

### DIFF
--- a/test/scale_in_test.go
+++ b/test/scale_in_test.go
@@ -125,7 +125,64 @@ func TestScaleIn_singleTaskGroupCountSetTooLow(t *testing.T) {
 					return nil
 				},
 				ExpectErr: true,
-				CheckErr:  acctest.CheckErrEqual("unexpected response code 304:"),
+				CheckErr:  acctest.CheckErrEqual("unexpected response code 409: scaling action will break job group minimum threshold"),
+			},
+			{
+				Runner: acctest.CheckTaskGroupCount(testScaleInGroupName1, 3),
+			},
+		},
+		CleanupFuncs: []acctest.TestStateFunc{acctest.CleanupSherpaPolicy, acctest.CleanupPurgeJob},
+	})
+}
+
+func TestScaleIn_singleTaskGroupPolicyDisabled(t *testing.T) {
+	if os.Getenv("SHERPA_ACC_META") != "" {
+		t.SkipNow()
+	}
+
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy := &api.JobGroupPolicy{Enabled: false, MaxCount: 2, MinCount: 1}
+					return s.Sherpa.Policies().WriteJobGroupPolicy(s.JobName, testScaleInGroupName1, policy)
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy1, err := s.Sherpa.Policies().ReadJobGroupPolicy(s.JobName, testScaleInGroupName1)
+					if err != nil {
+						return err
+					}
+
+					if policy1.MaxCount != 2 {
+						return fmt.Errorf("expected policy %s/%s to match the MaxCount", s.JobName, testMetaGroupName1)
+					}
+					if policy1.MinCount != 1 {
+						return fmt.Errorf("expected policy %s/%s to match the MinCount", s.JobName, testMetaGroupName1)
+					}
+					return nil
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					_, _, err := s.Nomad.Jobs().Register(buildScaleInTestJob(s.JobName), nil)
+					if err != nil {
+						return err
+					}
+					return acctest.CheckJobReachesStatus(s, "running")
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					_, err := s.Sherpa.Scale().JobGroupIn(s.JobName, testScaleInGroupName1, 10)
+					if err != nil {
+						return err
+					}
+					return nil
+				},
+				ExpectErr: true,
+				CheckErr:  acctest.CheckErrEqual("unexpected response code 409: job group scaling policy is currently disabled"),
 			},
 			{
 				Runner: acctest.CheckTaskGroupCount(testScaleInGroupName1, 3),


### PR DESCRIPTION
Previously errors when triggering a scaling action such as the
new count breaking policy thesholds would result in a 304 response
code and an empty message. This changes fixes the behaviour so
that the client will recieve a 409 response code with a useful
message to indicate the reason for not performing the action.

Closes #59