### PR TITLE
Fix issue when autoscaling job with mix of groups w/wo policies.

### DIFF
--- a/pkg/autoscale/autoscale.go
+++ b/pkg/autoscale/autoscale.go
@@ -113,8 +113,14 @@ func (a *AutoScale) getJobAllocations(jobID string, policies map[string]*policy.
 
 	for i := range allocs {
 
-		if !policies[allocs[i].TaskGroup].Enabled {
+		// GH-70: jobs can have a mix of groups with scaling policies, and groups without. We need
+		// to safely check the policy.
+		if v, ok := policies[allocs[i].TaskGroup]; !ok {
 			break
+		} else {
+			if !v.Enabled {
+				break
+			}
 		}
 
 		if !(allocs[i].ClientStatus == nomad.AllocClientStatusRunning || allocs[i].ClientStatus == nomad.AllocClientStatusPending) {


### PR DESCRIPTION
Jobs which had 2 groups, one which had a scaling policy and one
which did not would panic when running through the autoscaler.
This was caused by an unsafe check to see if an allocation was
part of a group which had a scaling policy.

Closes #70