### PR TITLE
Add cooldown functionality to scaling policies and storage backend.

### DIFF
--- a/cmd/policy/init/command.go
+++ b/cmd/policy/init/command.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	initPolicyCountSection = "{\"Enabled\":true,\"MaxCount\":16,\"MinCount\":4,\"ScaleOutCount\":2,\"ScaleInCount\":2,"
+	initPolicyCountSection = "{\"Enabled\":true,\"Cooldown\":120,\"MaxCount\":16,\"MinCount\":4,\"ScaleOutCount\":2,\"ScaleInCount\":2,"
 	thresholdPolicySection = "\"ScaleOutCPUPercentageThreshold\":75,\"ScaleOutMemoryPercentageThreshold\":75,\"ScaleInCPUPercentageThreshold\":30,\"ScaleInMemoryPercentageThreshold\":30}"
 )
 

--- a/cmd/policy/list/command.go
+++ b/cmd/policy/list/command.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	outputHeader = "Job:Group|Enabled|MinCount|MaxCount|ScaleInCount|ScaleOutCount"
+	outputHeader = "Job:Group|Enabled|MinCount|MaxCount|Cooldown|ScaleInCount|ScaleOutCount"
 )
 
 func RegisterCommand(rootCmd *cobra.Command) error {
@@ -59,8 +59,8 @@ func runList(_ *cobra.Command, args []string) {
 
 	for job, v := range *resp {
 		for group, pol := range v {
-			out = append(out, fmt.Sprintf("%s:%s|%v|%v|%v|%v|%v",
-				job, group, pol.Enabled, pol.MinCount, pol.MaxCount, pol.ScaleInCount, pol.ScaleOutCount))
+			out = append(out, fmt.Sprintf("%s:%s|%v|%v|%v|%v|%v|%v",
+				job, group, pol.Enabled, pol.MinCount, pol.MaxCount, pol.Cooldown, pol.ScaleInCount, pol.ScaleOutCount))
 		}
 	}
 	fmt.Println(helper.FormatList(out))

--- a/cmd/policy/read/command.go
+++ b/cmd/policy/read/command.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	outputHeader = "Group|Enabled|MinCount|MaxCount|ScaleInCount|ScaleOutCount"
+	outputHeader = "Group|Enabled|MinCount|MaxCount|Cooldown|ScaleInCount|ScaleOutCount"
 )
 
 func RegisterCommand(rootCmd *cobra.Command) error {
@@ -64,8 +64,8 @@ func runRead(_ *cobra.Command, args []string) {
 	out := []string{outputHeader}
 
 	for group, pol := range *resp {
-		out = append(out, fmt.Sprintf("%s|%v|%v|%v|%v|%v",
-			group, pol.Enabled, pol.MinCount, pol.MaxCount, pol.ScaleInCount, pol.ScaleOutCount))
+		out = append(out, fmt.Sprintf("%s|%v|%v|%v|%v|%v|%v",
+			group, pol.Enabled, pol.MinCount, pol.MaxCount, pol.Cooldown, pol.ScaleInCount, pol.ScaleOutCount))
 	}
 	fmt.Println(helper.FormatList(out))
 }

--- a/pkg/api/policy.go
+++ b/pkg/api/policy.go
@@ -12,13 +12,14 @@ func (c *Client) Policies() *Policies {
 	return &Policies{client: c}
 }
 
+// JobGroupPolicy represents an individual job group scaling policy.
 type JobGroupPolicy struct {
-	Enabled       bool
-	MaxCount      int
-	MinCount      int
-	ScaleOutCount int
-	ScaleInCount  int
-
+	Enabled                           bool
+	Cooldown                          int
+	MaxCount                          int
+	MinCount                          int
+	ScaleOutCount                     int
+	ScaleInCount                      int
 	ScaleOutCPUPercentageThreshold    int
 	ScaleOutMemoryPercentageThreshold int
 	ScaleInCPUPercentageThreshold     int

--- a/pkg/autoscale/autoscale.go
+++ b/pkg/autoscale/autoscale.go
@@ -7,7 +7,7 @@ import (
 	"github.com/jrasell/sherpa/pkg/state"
 )
 
-func (a *AutoScale) autoscaleJob(jobID string, policies map[string]*policy.GroupScalingPolicy) {
+func (a *AutoScale) autoscaleJob(jobID string, policies map[string]*policy.GroupScalingPolicy, t int64) {
 	resourceInfo, allocs, err := a.getJobAllocations(jobID, policies)
 	if err != nil {
 		a.logger.Error().
@@ -74,7 +74,13 @@ func (a *AutoScale) autoscaleJob(jobID string, policies map[string]*policy.Group
 		}
 
 		if scalingDir != "" {
-			req := &scale.GroupReq{Direction: scalingDir, Count: count, GroupName: group, GroupScalingPolicy: pol}
+			req := &scale.GroupReq{
+				Direction:          scalingDir,
+				Count:              count,
+				GroupName:          group,
+				GroupScalingPolicy: pol,
+				Time:               t,
+			}
 			scaleReq = append(scaleReq, req)
 
 			a.logger.Debug().

--- a/pkg/policy/backend/nomadmeta/consts.go
+++ b/pkg/policy/backend/nomadmeta/consts.go
@@ -2,6 +2,7 @@ package nomadmeta
 
 const (
 	metaKeyEnabled                           = "sherpa_enabled"
+	metaKeyCooldown                          = "sherpa_cooldown"
 	metaKeyMaxCount                          = "sherpa_max_count"
 	metaKeyMinCount                          = "sherpa_min_count"
 	metaKeyScaleInCount                      = "sherpa_scale_in_count"

--- a/pkg/policy/backend/nomadmeta/processor.go
+++ b/pkg/policy/backend/nomadmeta/processor.go
@@ -103,6 +103,7 @@ func (pr *Processor) policyFromMeta(meta map[string]string) *policy.GroupScaling
 		MaxCount:                          pr.maxCountValueOrDefault(meta),
 		MinCount:                          pr.minCountValueOrDefault(meta),
 		Enabled:                           pr.enabledValueOrDefault(meta),
+		Cooldown:                          pr.cooldownValueOrDefault(meta),
 		ScaleInCount:                      pr.scaleInValueOrDefault(meta),
 		ScaleOutCount:                     pr.scaleOutValueOrDefault(meta),
 		ScaleOutCPUPercentageThreshold:    pr.scaleOutCPUThresholdValueOrDefault(meta),
@@ -122,6 +123,18 @@ func (pr *Processor) enabledValueOrDefault(meta map[string]string) bool {
 		return enabled
 	}
 	return false
+}
+
+func (pr *Processor) cooldownValueOrDefault(meta map[string]string) int {
+	if val, ok := meta[metaKeyCooldown]; ok {
+		cooldown, err := strconv.Atoi(val)
+		if err != nil {
+			pr.logger.Error().Err(err).Msg("failed to convert cooldown meta value to int")
+			return policy.DefaultCooldown
+		}
+		return cooldown
+	}
+	return policy.DefaultCooldown
 }
 
 func (pr *Processor) maxCountValueOrDefault(meta map[string]string) int {

--- a/pkg/policy/backend/nomadmeta/processor_test.go
+++ b/pkg/policy/backend/nomadmeta/processor_test.go
@@ -18,6 +18,7 @@ func TestProcessor_policyFromMeta(t *testing.T) {
 		{
 			meta: map[string]string{
 				metaKeyEnabled:                           "true",
+				metaKeyCooldown:                          "10",
 				metaKeyMaxCount:                          "100",
 				metaKeyMinCount:                          "50",
 				metaKeyScaleInCount:                      "3",
@@ -29,6 +30,7 @@ func TestProcessor_policyFromMeta(t *testing.T) {
 			},
 			expectedPolicy: &policy.GroupScalingPolicy{
 				Enabled:                           true,
+				Cooldown:                          10,
 				MinCount:                          50,
 				MaxCount:                          100,
 				ScaleOutCount:                     7,
@@ -45,6 +47,7 @@ func TestProcessor_policyFromMeta(t *testing.T) {
 			},
 			expectedPolicy: &policy.GroupScalingPolicy{
 				Enabled:                           true,
+				Cooldown:                          180,
 				MinCount:                          2,
 				MaxCount:                          10,
 				ScaleOutCount:                     1,
@@ -61,6 +64,7 @@ func TestProcessor_policyFromMeta(t *testing.T) {
 			},
 			expectedPolicy: &policy.GroupScalingPolicy{
 				Enabled:                           false,
+				Cooldown:                          180,
 				MinCount:                          2,
 				MaxCount:                          10,
 				ScaleOutCount:                     1,
@@ -74,6 +78,7 @@ func TestProcessor_policyFromMeta(t *testing.T) {
 		{
 			meta: map[string]string{
 				metaKeyEnabled:                           "true",
+				metaKeyCooldown:                          "18000",
 				metaKeyMaxCount:                          "10000",
 				metaKeyScaleOutCount:                     "1000",
 				metaKeyScaleInCount:                      "10",
@@ -84,6 +89,7 @@ func TestProcessor_policyFromMeta(t *testing.T) {
 			},
 			expectedPolicy: &policy.GroupScalingPolicy{
 				Enabled:                           true,
+				Cooldown:                          18000,
 				MinCount:                          2,
 				MaxCount:                          10000,
 				ScaleOutCount:                     1000,
@@ -97,6 +103,7 @@ func TestProcessor_policyFromMeta(t *testing.T) {
 		{
 			meta: map[string]string{
 				metaKeyEnabled:                           "untranslatable",
+				metaKeyCooldown:                          "untranslatable",
 				metaKeyMinCount:                          "untranslatable",
 				metaKeyMaxCount:                          "untranslatable",
 				metaKeyScaleOutCount:                     "untranslatable",
@@ -108,6 +115,7 @@ func TestProcessor_policyFromMeta(t *testing.T) {
 			},
 			expectedPolicy: &policy.GroupScalingPolicy{
 				Enabled:                           false,
+				Cooldown:                          180,
 				MinCount:                          2,
 				MaxCount:                          10,
 				ScaleOutCount:                     1,

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -5,6 +5,11 @@ type GroupScalingPolicy struct {
 	// Enabled is a boolean which tells whether the policy is disabled or not.
 	Enabled bool `json:"Enabled"`
 
+	// Cooldown is a time period in seconds. Once a scaling action has been triggered on the
+	// desired group, another action will not be triggered until the cooldown period has
+	// passed.
+	Cooldown int `json:"Cooldown"`
+
 	// MinCount is the minimum count a task group should reach.
 	MinCount int `json:"MinCount"`
 
@@ -27,6 +32,7 @@ type GroupScalingPolicy struct {
 const (
 	DefaultMinCount                          = 2
 	DefaultMaxCount                          = 10
+	DefaultCooldown                          = 180
 	DefaultScaleOutCount                     = 1
 	DefaultScaleInCount                      = 1
 	DefaultScaleOutCPUPercentageThreshold    = 80

--- a/pkg/policy/v1/policies_test.go
+++ b/pkg/policy/v1/policies_test.go
@@ -19,6 +19,7 @@ func Test_decodeGroupPolicyReqBodyAndValidate(t *testing.T) {
 				Enabled:                           true,
 				MaxCount:                          10,
 				MinCount:                          2,
+				Cooldown:                          180,
 				ScaleInCount:                      1,
 				ScaleOutCount:                     1,
 				ScaleInCPUPercentageThreshold:     20,

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -6,6 +6,7 @@ import "github.com/pkg/errors"
 func Validate(pol *GroupScalingPolicy) error {
 	if pol.MinCount == 0 &&
 		pol.MaxCount == 0 &&
+		pol.Cooldown == 0 &&
 		!pol.Enabled &&
 		pol.ScaleInCount == 0 &&
 		pol.ScaleOutCount == 0 {
@@ -22,6 +23,9 @@ func MergeWithDefaults(pol *GroupScalingPolicy) {
 	}
 	if pol.MaxCount == 0 {
 		pol.MaxCount = DefaultMaxCount
+	}
+	if pol.Cooldown == 0 {
+		pol.Cooldown = DefaultCooldown
 	}
 	if pol.ScaleOutCount == 0 {
 		pol.ScaleOutCount = DefaultScaleOutCount

--- a/pkg/policy/validate_test.go
+++ b/pkg/policy/validate_test.go
@@ -37,6 +37,7 @@ func Test_MergeWithDefaults(t *testing.T) {
 				Enabled:                           true,
 				MinCount:                          DefaultMinCount,
 				MaxCount:                          DefaultMaxCount,
+				Cooldown:                          DefaultCooldown,
 				ScaleInCount:                      DefaultScaleInCount,
 				ScaleOutCount:                     DefaultScaleOutCount,
 				ScaleOutCPUPercentageThreshold:    DefaultScaleOutCPUPercentageThreshold,

--- a/pkg/scale/consts.go
+++ b/pkg/scale/consts.go
@@ -24,6 +24,10 @@ type Scale interface {
 	// currently in deployment.
 	JobGroupIsDeploying(job, group string) bool
 
+	// JobGroupIsInCooldown checks whether the job group in question is currently in scaling
+	// cooldown using the input time as the comparison.
+	JobGroupIsInCooldown(job, group string, cooldown int, time int64) (bool, error)
+
 	checkJobGroupExists(*api.Job, string) *api.TaskGroup
 
 	getNewGroupCount(*api.TaskGroup, *GroupReq) int
@@ -48,6 +52,11 @@ type GroupReq struct {
 	// GroupScalingPolicy should include the job group scaling policy if it exists within the
 	// Sherpa server.
 	GroupScalingPolicy *policy.GroupScalingPolicy
+
+	// Time is the UnixNano time representation which indicates when this scaling request was first
+	// triggered. This is to help coordinate with checks such as cooldown and ensure a single time
+	// can be used.
+	Time int64
 }
 
 type ScalingResponse struct {

--- a/pkg/scale/cooldown.go
+++ b/pkg/scale/cooldown.go
@@ -1,0 +1,22 @@
+package scale
+
+// JobGroupIsInCooldown satisfies the JobGroupIsInCooldown func within the Scale interface.
+func (s *Scaler) JobGroupIsInCooldown(job, group string, cooldown int, time int64) (bool, error) {
+
+	// Pull the latest scaling event for the job group out of the state.
+	last, err := s.state.GetLatestScalingEvent(job, group)
+	if err != nil {
+		return true, err
+	}
+
+	// It is possible to return nil for the last event. This means that we were able to call the
+	// backend successfully, but there is no latest event for the job group.
+	if last == nil {
+		return false, nil
+	}
+
+	if (time - int64(cooldown*1000000000)) < last.Time {
+		return true, nil
+	}
+	return false, nil
+}

--- a/pkg/scale/cooldown_test.go
+++ b/pkg/scale/cooldown_test.go
@@ -1,0 +1,84 @@
+package scale
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/jrasell/sherpa/pkg/helper"
+	"github.com/jrasell/sherpa/pkg/state"
+	stateMemory "github.com/jrasell/sherpa/pkg/state/scale/memory"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScaler_JobGroupIsInCooldown(t *testing.T) {
+	testCases := []struct {
+		inputJobName         string
+		inputGroupName       string
+		inputCoolDown        int
+		inputTime            int64
+		lastScalingEvent     *state.ScalingEventMessage
+		expectedCooldownResp bool
+		name                 string
+	}{
+		{
+			inputJobName:         "test-job-1",
+			inputGroupName:       "test-group-1",
+			inputCoolDown:        180,
+			inputTime:            helper.GenerateEventTimestamp(),
+			expectedCooldownResp: true,
+			name:                 "job group with policy cooldown set is in scaling cooldown",
+			lastScalingEvent: &state.ScalingEventMessage{
+				ID:        uuid.UUID{},
+				GroupName: "test-group-1",
+				EvalID:    "test",
+				Source:    "test",
+				Time:      helper.GenerateEventTimestamp(),
+				Status:    "test",
+				Count:     1,
+				Direction: "in",
+			},
+		},
+		{
+			inputJobName:         "test-job-1",
+			inputGroupName:       "test-group-1",
+			inputTime:            helper.GenerateEventTimestamp(),
+			expectedCooldownResp: false,
+			name:                 "job group without previous scaling event",
+			lastScalingEvent:     nil,
+		},
+		{
+			inputJobName:         "test-job-1",
+			inputGroupName:       "test-group-1",
+			inputCoolDown:        300,
+			inputTime:            helper.GenerateEventTimestamp(),
+			expectedCooldownResp: false,
+			name:                 "job group policy with cooldown but last event long ago",
+			lastScalingEvent: &state.ScalingEventMessage{
+				ID:        uuid.UUID{},
+				GroupName: "test-group-1",
+				EvalID:    "test",
+				Source:    "test",
+				Time:      helper.GenerateEventTimestamp() - 1000000000000,
+				Status:    "test",
+				Count:     1,
+				Direction: "in",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+
+		// Create a new Scaler for each test, to ensure to conflicting resources.
+		sc := Scaler{logger: zerolog.Logger{}, nomadClient: nil, state: stateMemory.NewStateBackend(), strict: true}
+
+		// Write the last event to check against if this isn't nil, meaning we do not have one.
+		if tc.lastScalingEvent != nil {
+			assert.Nil(t, sc.state.PutScalingEvent(tc.inputJobName, tc.lastScalingEvent), tc.name)
+		}
+
+		cooldown, err := sc.JobGroupIsInCooldown(tc.inputJobName, tc.inputGroupName, tc.inputCoolDown, tc.inputTime)
+		assert.Nil(t, err, tc.name)
+		assert.Equal(t, tc.expectedCooldownResp, cooldown, tc.name)
+	}
+}

--- a/pkg/scale/event.go
+++ b/pkg/scale/event.go
@@ -2,7 +2,6 @@ package scale
 
 import (
 	"github.com/gofrs/uuid"
-	"github.com/jrasell/sherpa/pkg/helper"
 	"github.com/jrasell/sherpa/pkg/state"
 )
 
@@ -22,7 +21,7 @@ func (s *Scaler) sendScalingEventToState(job, id string, source state.Source, gr
 			GroupName: groupReqs[i].GroupName,
 			Status:    status,
 			Source:    source,
-			Time:      helper.GenerateEventTimestamp(),
+			Time:      groupReqs[i].Time,
 			Count:     groupReqs[i].Count,
 			Direction: groupReqs[i].Direction.String(),
 		}

--- a/pkg/scale/v1/consts.go
+++ b/pkg/scale/v1/consts.go
@@ -14,6 +14,7 @@ const (
 	countFailed                = 0
 	headerKeyContentType       = "Content-Type"
 	headerValueContentTypeJSON = "application/json; charset=utf-8"
+	jobGroupInCooldownMsg      = "job group is currently in scaling cooldown"
 )
 
 var (

--- a/pkg/state/scale/backend.go
+++ b/pkg/state/scale/backend.go
@@ -8,6 +8,15 @@ import (
 // Backend is the interface required for a state storage backend. A state storage backend is used
 // to durably store job scaling state outside of Sherpa.
 type Backend interface {
+
+	// GetLatestScalingEvents is used to pull all the currently stored latest scaling events from
+	// the storage backend.
+	GetLatestScalingEvents() (map[string]*state.ScalingEvent, error)
+
+	// GetLatestScalingEvent is used to pull the latest scaling event for the particular job group
+	// from the storage backend if we have a record.
+	GetLatestScalingEvent(job, group string) (*state.ScalingEvent, error)
+
 	// GetScalingEvents returns all scaling events held within the state.
 	GetScalingEvents() (map[uuid.UUID]map[string]*state.ScalingEvent, error)
 

--- a/pkg/state/scale/memory/memory.go
+++ b/pkg/state/scale/memory/memory.go
@@ -27,11 +27,25 @@ func NewStateBackend() scale.Backend {
 	}
 }
 
+func (s *StateBackend) GetLatestScalingEvents() (map[string]*state.ScalingEvent, error) {
+	s.RLock()
+	latest := s.state.LatestEvents
+	s.RUnlock()
+	return latest, nil
+}
+
+func (s *StateBackend) GetLatestScalingEvent(job, group string) (*state.ScalingEvent, error) {
+	s.RLock()
+	latest := s.state.LatestEvents[job+":"+group]
+	s.RUnlock()
+	return latest, nil
+}
+
 func (s *StateBackend) GetScalingEvents() (map[uuid.UUID]map[string]*state.ScalingEvent, error) {
 	s.RLock()
-	state := s.state.Events
+	events := s.state.Events
 	s.RUnlock()
-	return state, nil
+	return events, nil
 }
 
 func (s *StateBackend) PutScalingEvent(job string, event *state.ScalingEventMessage) error {

--- a/test/scale_in_test.go
+++ b/test/scale_in_test.go
@@ -192,6 +192,77 @@ func TestScaleIn_singleTaskGroupPolicyDisabled(t *testing.T) {
 	})
 }
 
+func TestScaleIn_singleTaskGroupWithHighCooldown(t *testing.T) {
+	if os.Getenv("SHERPA_ACC_META") != "" {
+		t.SkipNow()
+	}
+
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy := &api.JobGroupPolicy{Enabled: true, Cooldown: 600, MinCount: 1}
+					return s.Sherpa.Policies().WriteJobGroupPolicy(s.JobName, testScaleInGroupName1, policy)
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy1, err := s.Sherpa.Policies().ReadJobGroupPolicy(s.JobName, testScaleInGroupName1)
+					if err != nil {
+						return err
+					}
+
+					if policy1.Cooldown != 600 {
+						return fmt.Errorf("expected policy %s/%s to match the Cooldown", s.JobName, testMetaGroupName1)
+					}
+					return nil
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					_, _, err := s.Nomad.Jobs().Register(buildScaleInTestJob(s.JobName), nil)
+					if err != nil {
+						return err
+					}
+					return acctest.CheckJobReachesStatus(s, "running")
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					resp, err := s.Sherpa.Scale().JobGroupIn(s.JobName, testScaleInGroupName1, 2)
+					if err != nil {
+						return err
+					}
+
+					if resp == nil {
+						return fmt.Errorf("expected non-nil scale out response")
+					}
+
+					if _, err = s.Sherpa.Scale().Info(resp.ID.String()); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					_, err := s.Sherpa.Scale().JobGroupIn(s.JobName, testScaleInGroupName1, 1)
+					if err != nil {
+						return err
+					}
+					return nil
+				},
+				ExpectErr: true,
+				CheckErr:  acctest.CheckErrEqual("unexpected response code 409: job group is currently in scaling cooldown"),
+			},
+			{
+				Runner: acctest.CheckTaskGroupCount(testScaleInGroupName1, 1),
+			},
+		},
+		CleanupFuncs: []acctest.TestStateFunc{acctest.CleanupSherpaPolicy, acctest.CleanupPurgeJob},
+	})
+}
+
 func buildScaleInTestJob(name string) *nomad.Job {
 	j := acctest.BuildBaseTestJob(name)
 	j.TaskGroups = append(j.TaskGroups, acctest.BuildBaseTaskGroup(testScaleInGroupName1, testScaleInTaskName1))

--- a/test/scale_out_test.go
+++ b/test/scale_out_test.go
@@ -192,6 +192,77 @@ func TestScaleOut_singleTaskGroupPolicyDisabled(t *testing.T) {
 	})
 }
 
+func TestScaleOut_singleTaskGroupWithHighCooldown(t *testing.T) {
+	if os.Getenv("SHERPA_ACC_META") != "" {
+		t.SkipNow()
+	}
+
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy := &api.JobGroupPolicy{Enabled: true, Cooldown: 600, MinCount: 1}
+					return s.Sherpa.Policies().WriteJobGroupPolicy(s.JobName, testScaleOutGroupName1, policy)
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					policy1, err := s.Sherpa.Policies().ReadJobGroupPolicy(s.JobName, testScaleOutGroupName1)
+					if err != nil {
+						return err
+					}
+
+					if policy1.Cooldown != 600 {
+						return fmt.Errorf("expected policy %s/%s to match the Cooldown", s.JobName, testScaleOutGroupName1)
+					}
+					return nil
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					_, _, err := s.Nomad.Jobs().Register(buildScaleInTestJob(s.JobName), nil)
+					if err != nil {
+						return err
+					}
+					return acctest.CheckJobReachesStatus(s, "running")
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					resp, err := s.Sherpa.Scale().JobGroupOut(s.JobName, testScaleOutGroupName1, 3)
+					if err != nil {
+						return err
+					}
+
+					if resp == nil {
+						return fmt.Errorf("expected non-nil scale out response")
+					}
+
+					if _, err = s.Sherpa.Scale().Info(resp.ID.String()); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			{
+				Runner: func(s *acctest.TestState) error {
+					_, err := s.Sherpa.Scale().JobGroupIn(s.JobName, testScaleOutGroupName1, 1)
+					if err != nil {
+						return err
+					}
+					return nil
+				},
+				ExpectErr: true,
+				CheckErr:  acctest.CheckErrEqual("unexpected response code 409: job group is currently in scaling cooldown"),
+			},
+			{
+				Runner: acctest.CheckTaskGroupCount(testScaleOutGroupName1, 6),
+			},
+		},
+		CleanupFuncs: []acctest.TestStateFunc{acctest.CleanupSherpaPolicy, acctest.CleanupPurgeJob},
+	})
+}
+
 func buildScaleOutTestJob(name string) *nomad.Job {
 	j := acctest.BuildBaseTestJob(name)
 	j.TaskGroups = append(j.TaskGroups, acctest.BuildBaseTaskGroup(testScaleOutGroupName1, testScaleOutTaskName1))


### PR DESCRIPTION
Sherpa policies now allow the specifying of a cooldown as a time
duration in seconds. When a scaling activity is requested, the
cooldown is checked against the last scaling event for the job
group. If the last event has occurred within the cooldown period,
the scaling request will be denied.

Closes #49