### PR TITLE
cluster: fix a big where cluster state get overwritten on restart.

### DIFF
--- a/pkg/server/cluster/cluster.go
+++ b/pkg/server/cluster/cluster.go
@@ -22,9 +22,8 @@ func (m *Member) setupCluster() error {
 	// If existing state is found, check whether the operator passed cluster name matches the one
 	// found. If the passed one does not match the state, we will fail with an error.
 	if c.Name != "" && c.ID != uuid.Nil {
-		if err := m.verifyClusterName(c.Name); err != nil {
-			return err
-		}
+		m.logger.Debug().Msg("found existing Sherpa cluster state, verifying data")
+		return m.verifyClusterName(c.Name)
 	}
 
 	if err := m.generateClusterName(); err != nil {
@@ -49,7 +48,7 @@ func (m *Member) verifyClusterName(name string) error {
 		}
 	}
 
-	m.logger.Info().Msg("successfully found cluster state of existing cluster to join")
+	m.logger.Info().Msg("successfully verified state of existing cluster to join")
 	m.clusterName = name
 	return nil
 }

--- a/pkg/server/cluster/member.go
+++ b/pkg/server/cluster/member.go
@@ -25,7 +25,7 @@ type Member struct { // nolint:maligned
 	stateLock sync.RWMutex
 	logger    zerolog.Logger
 
-	// clusterName
+	// clusterName represents the name of the cluster this Sherpa instance is a part of.
 	clusterName string
 
 	// standby is used to determine whether the Sherpa server in question is currently in standby


### PR DESCRIPTION
The cluster package was not acting correctly when discovering
existing cluster state. This meant that cluster info was being
overwritten which is not the intended behaviour. This now fixes
the issue.

closes #76