### PR TITLE
autoscale: provide additional decision context on scaling choices

### DIFF
--- a/pkg/autoscale/decision.go
+++ b/pkg/autoscale/decision.go
@@ -1,0 +1,126 @@
+package autoscale
+
+import (
+	"github.com/jrasell/sherpa/pkg/policy"
+	"github.com/jrasell/sherpa/pkg/scale"
+	"github.com/rs/zerolog"
+)
+
+// scalingCheckParams is used to perform a decision check on a particular job group.
+type scalingCheckParams struct {
+	resourceUsage *scalingMetrics
+	logger        zerolog.Logger
+	policy        *policy.GroupScalingPolicy
+}
+
+type scalingMetrics struct {
+	cpu    int
+	memory int
+}
+
+type scalingDecision struct {
+	direction scale.Direction
+	count     int
+	metrics   map[string]*scalingMetricDecision
+}
+
+type scalingMetricDecision struct {
+	usage     int
+	threshold int
+}
+
+// calculateScalingDecision is used to determine whether or not a scaling action is desired for the
+// job group in question.
+func calculateScalingDecision(params *scalingCheckParams) *scalingDecision {
+	var inDecision, outDecision *scalingDecision
+
+	// Grab our decisions for analysing.
+	inDecision = isScalingInRequired(params)
+	outDecision = isScalingOutRequired(params)
+
+	// Check if it has been decided we should scale both out and in. This happens when a groups
+	// resource settings are suboptimal and one resource parameter is over-provisioned, and the
+	// other is under-provisioned. Performing this check allows operators to clearly see this is
+	// happening and potentially take action. It is possible in the future, this could be a feature
+	// of Sherpa.
+	if inDecision.direction != scale.DirectionNone && outDecision.direction != scale.DirectionNone {
+		params.logger.Info().Msg("both scale in and scale out actions desired, using out action")
+		return outDecision
+	}
+
+	if outDecision.direction != scale.DirectionNone {
+		return outDecision
+	}
+
+	if inDecision.direction != scale.DirectionNone {
+		return inDecision
+	}
+
+	return nil
+}
+
+func isScalingOutRequired(params *scalingCheckParams) *scalingDecision {
+	resp := scalingDecision{metrics: make(map[string]*scalingMetricDecision), direction: scale.DirectionNone}
+
+	// Perform a check to see if scaling in is required based on CPU utilisation.
+	if params.resourceUsage.cpu > params.policy.ScaleOutCPUPercentageThreshold {
+		resp.metrics["cpu"] = &scalingMetricDecision{
+			usage:     params.resourceUsage.cpu,
+			threshold: params.policy.ScaleOutCPUPercentageThreshold,
+		}
+		resp.direction = scale.DirectionOut
+		resp.count = params.policy.ScaleOutCount
+	}
+
+	// Perform a check to see if scaling in is required based on memory utilisation.
+	if params.resourceUsage.memory > params.policy.ScaleOutMemoryPercentageThreshold {
+		resp.metrics["memory"] = &scalingMetricDecision{
+			usage:     params.resourceUsage.memory,
+			threshold: params.policy.ScaleOutMemoryPercentageThreshold,
+		}
+		resp.direction = scale.DirectionOut
+		resp.count = params.policy.ScaleOutCount
+	}
+
+	return &resp
+}
+
+func isScalingInRequired(params *scalingCheckParams) *scalingDecision {
+	resp := scalingDecision{metrics: make(map[string]*scalingMetricDecision), direction: scale.DirectionNone}
+
+	// Perform a check to see if scaling in is required based on CPU utilisation.
+	if params.resourceUsage.cpu < params.policy.ScaleInCPUPercentageThreshold {
+		resp.metrics["cpu"] = &scalingMetricDecision{
+			usage:     params.resourceUsage.cpu,
+			threshold: params.policy.ScaleInCPUPercentageThreshold,
+		}
+		resp.direction = scale.DirectionIn
+		resp.count = params.policy.ScaleInCount
+	}
+
+	// Perform a check to see if scaling in is required based on memory utilisation.
+	if params.resourceUsage.memory < params.policy.ScaleInMemoryPercentageThreshold {
+		resp.metrics["memory"] = &scalingMetricDecision{
+			usage:     params.resourceUsage.memory,
+			threshold: params.policy.ScaleInMemoryPercentageThreshold,
+		}
+		resp.direction = scale.DirectionIn
+		resp.count = params.policy.ScaleInCount
+	}
+
+	return &resp
+}
+
+// MarshalZerologObject is used to marshal a scaling decision for logging with zerolog.
+func (sd *scalingDecision) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("direction", sd.direction.String()).Int("count", sd.count)
+
+	dict := zerolog.Dict()
+
+	for metric, val := range sd.metrics {
+		dict.Dict(metric, zerolog.Dict().
+			Int("threshold-percentage", val.threshold).
+			Int("usage-percentage", val.usage))
+	}
+	e.Dict("resources", dict)
+}

--- a/pkg/autoscale/decision_test.go
+++ b/pkg/autoscale/decision_test.go
@@ -1,0 +1,205 @@
+package autoscale
+
+import (
+	"testing"
+
+	"github.com/jrasell/sherpa/pkg/policy"
+	"github.com/jrasell/sherpa/pkg/scale"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_calculateScalingDecision(t *testing.T) {
+	testCases := []struct {
+		inputParams    *scalingCheckParams
+		expectedOutput *scalingDecision
+		name           string
+	}{
+		{
+			inputParams: &scalingCheckParams{
+				resourceUsage: &scalingMetrics{
+					cpu:    50,
+					memory: 50,
+				},
+				logger: zerolog.Logger{},
+				policy: &policy.GroupScalingPolicy{
+					ScaleOutCount:                     2,
+					ScaleInCount:                      2,
+					ScaleOutCPUPercentageThreshold:    75,
+					ScaleOutMemoryPercentageThreshold: 75,
+					ScaleInCPUPercentageThreshold:     30,
+					ScaleInMemoryPercentageThreshold:  30,
+				},
+			},
+			expectedOutput: nil,
+			name:           "cpu scale none, memory scale none",
+		},
+		{
+			inputParams: &scalingCheckParams{
+				resourceUsage: &scalingMetrics{
+					cpu:    80,
+					memory: 50,
+				},
+				logger: zerolog.Logger{},
+				policy: &policy.GroupScalingPolicy{
+					ScaleOutCount:                     2,
+					ScaleInCount:                      2,
+					ScaleOutCPUPercentageThreshold:    75,
+					ScaleOutMemoryPercentageThreshold: 75,
+					ScaleInCPUPercentageThreshold:     30,
+					ScaleInMemoryPercentageThreshold:  30,
+				},
+			},
+			expectedOutput: &scalingDecision{
+				direction: scale.DirectionOut,
+				count:     2,
+				metrics:   map[string]*scalingMetricDecision{"cpu": {usage: 80, threshold: 75}},
+			},
+			name: "cpu scale out, memory scale none",
+		},
+		{
+			inputParams: &scalingCheckParams{
+				resourceUsage: &scalingMetrics{
+					cpu:    50,
+					memory: 80,
+				},
+				logger: zerolog.Logger{},
+				policy: &policy.GroupScalingPolicy{
+					ScaleOutCount:                     2,
+					ScaleInCount:                      2,
+					ScaleOutCPUPercentageThreshold:    75,
+					ScaleOutMemoryPercentageThreshold: 75,
+					ScaleInCPUPercentageThreshold:     30,
+					ScaleInMemoryPercentageThreshold:  30,
+				},
+			},
+			expectedOutput: &scalingDecision{
+				direction: scale.DirectionOut,
+				count:     2,
+				metrics:   map[string]*scalingMetricDecision{"memory": {usage: 80, threshold: 75}},
+			},
+			name: "cpu scale none, memory scale out",
+		},
+		{
+			inputParams: &scalingCheckParams{
+				resourceUsage: &scalingMetrics{
+					cpu:    80,
+					memory: 80,
+				},
+				logger: zerolog.Logger{},
+				policy: &policy.GroupScalingPolicy{
+					ScaleOutCount:                     2,
+					ScaleInCount:                      2,
+					ScaleOutCPUPercentageThreshold:    75,
+					ScaleOutMemoryPercentageThreshold: 75,
+					ScaleInCPUPercentageThreshold:     30,
+					ScaleInMemoryPercentageThreshold:  30,
+				},
+			},
+			expectedOutput: &scalingDecision{
+				direction: scale.DirectionOut,
+				count:     2,
+				metrics:   map[string]*scalingMetricDecision{"memory": {usage: 80, threshold: 75}, "cpu": {usage: 80, threshold: 75}},
+			},
+			name: "cpu scale out, memory scale out",
+		},
+
+		{
+			inputParams: &scalingCheckParams{
+				resourceUsage: &scalingMetrics{
+					cpu:    20,
+					memory: 50,
+				},
+				logger: zerolog.Logger{},
+				policy: &policy.GroupScalingPolicy{
+					ScaleOutCount:                     2,
+					ScaleInCount:                      2,
+					ScaleOutCPUPercentageThreshold:    75,
+					ScaleOutMemoryPercentageThreshold: 75,
+					ScaleInCPUPercentageThreshold:     30,
+					ScaleInMemoryPercentageThreshold:  30,
+				},
+			},
+			expectedOutput: &scalingDecision{
+				direction: scale.DirectionIn,
+				count:     2,
+				metrics:   map[string]*scalingMetricDecision{"cpu": {usage: 20, threshold: 30}},
+			},
+			name: "cpu scale in, memory scale none",
+		},
+		{
+			inputParams: &scalingCheckParams{
+				resourceUsage: &scalingMetrics{
+					cpu:    50,
+					memory: 20,
+				},
+				logger: zerolog.Logger{},
+				policy: &policy.GroupScalingPolicy{
+					ScaleOutCount:                     2,
+					ScaleInCount:                      2,
+					ScaleOutCPUPercentageThreshold:    75,
+					ScaleOutMemoryPercentageThreshold: 75,
+					ScaleInCPUPercentageThreshold:     30,
+					ScaleInMemoryPercentageThreshold:  30,
+				},
+			},
+			expectedOutput: &scalingDecision{
+				direction: scale.DirectionIn,
+				count:     2,
+				metrics:   map[string]*scalingMetricDecision{"memory": {usage: 20, threshold: 30}},
+			},
+			name: "cpu scale none, memory scale in",
+		},
+		{
+			inputParams: &scalingCheckParams{
+				resourceUsage: &scalingMetrics{
+					cpu:    20,
+					memory: 20,
+				},
+				logger: zerolog.Logger{},
+				policy: &policy.GroupScalingPolicy{
+					ScaleOutCount:                     2,
+					ScaleInCount:                      2,
+					ScaleOutCPUPercentageThreshold:    75,
+					ScaleOutMemoryPercentageThreshold: 75,
+					ScaleInCPUPercentageThreshold:     30,
+					ScaleInMemoryPercentageThreshold:  30,
+				},
+			},
+			expectedOutput: &scalingDecision{
+				direction: scale.DirectionIn,
+				count:     2,
+				metrics:   map[string]*scalingMetricDecision{"memory": {usage: 20, threshold: 30}, "cpu": {usage: 20, threshold: 30}},
+			},
+			name: "cpu scale in, memory scale in",
+		},
+		{
+			inputParams: &scalingCheckParams{
+				resourceUsage: &scalingMetrics{
+					cpu:    90,
+					memory: 10,
+				},
+				logger: zerolog.Logger{},
+				policy: &policy.GroupScalingPolicy{
+					ScaleOutCount:                     2,
+					ScaleInCount:                      2,
+					ScaleOutCPUPercentageThreshold:    75,
+					ScaleOutMemoryPercentageThreshold: 75,
+					ScaleInCPUPercentageThreshold:     30,
+					ScaleInMemoryPercentageThreshold:  30,
+				},
+			},
+			expectedOutput: &scalingDecision{
+				direction: scale.DirectionOut,
+				count:     2,
+				metrics:   map[string]*scalingMetricDecision{"cpu": {usage: 90, threshold: 75}},
+			},
+			name: "cpu scale out, memory scale in",
+		},
+	}
+
+	for _, tc := range testCases {
+		actualOutput := calculateScalingDecision(tc.inputParams)
+		assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+	}
+}

--- a/pkg/helper/logger.go
+++ b/pkg/helper/logger.go
@@ -1,0 +1,13 @@
+package helper
+
+import "github.com/rs/zerolog"
+
+// LoggerWithJobContext adds the job name to the logger as context.
+func LoggerWithJobContext(logger zerolog.Logger, job string) zerolog.Logger {
+	return logger.With().Str("job", job).Logger()
+}
+
+// LoggerWithGroupContext adds the group name to the logger as context.
+func LoggerWithGroupContext(logger zerolog.Logger, group string) zerolog.Logger {
+	return logger.With().Str("group", group).Logger()
+}

--- a/pkg/scale/direction.go
+++ b/pkg/scale/direction.go
@@ -3,8 +3,9 @@ package scale
 type Direction string
 
 const (
-	DirectionIn  Direction = "in"
-	DirectionOut Direction = "out"
+	DirectionIn   Direction = "in"
+	DirectionOut  Direction = "out"
+	DirectionNone Direction = "none"
 )
 
 func (d *Direction) String() string {

--- a/pkg/scale/direction_test.go
+++ b/pkg/scale/direction_test.go
@@ -13,6 +13,7 @@ func TestDirection_String(t *testing.T) {
 	}{
 		{direction: DirectionOut, expectedResp: "out"},
 		{direction: DirectionIn, expectedResp: "in"},
+		{direction: DirectionNone, expectedResp: "none"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
When the autoscaler performs its logic to figure out whether a
scaling event should be triggered, it uses a case statement to
check if thresholds are broken. The problem with this is that the
first match is used, which is correct, but doesn't provide a great
amount of detail. It is possible that both out and in actions are
desired by different resources, or that multiple resources both
require the same action.

This change allows for greater insight into the scaling decision
made by the autoscaler calculation. It helps operators understand
if changes need to be made to group resource settings, or exactly
which thresholds were broken.