### PR TITLE
autoscale: meta submission allows multiple resource entrie.

### DIFF
--- a/pkg/autoscale/autoscale.go
+++ b/pkg/autoscale/autoscale.go
@@ -1,7 +1,6 @@
 package autoscale
 
 import (
-	"fmt"
 	"strconv"
 
 	nomad "github.com/hashicorp/nomad/api"
@@ -188,8 +187,7 @@ func updateResourceTracker(group string, cpu, mem int, tracker map[string]*scala
 
 // updateAutoscaleMeta populates meta with the metrics used to autoscale a job group
 func updateAutoscaleMeta(group, metricType string, value, threshold int, meta map[string]string) {
-	key := fmt.Sprintf("group-%s-metric", group)
-	meta[key+"-type"] = metricType
+	key := group + "-" + metricType
 	meta[key+"-value"] = strconv.Itoa(value)
 	meta[key+"-threshold"] = strconv.Itoa(threshold)
 }

--- a/pkg/autoscale/autoscale_test.go
+++ b/pkg/autoscale/autoscale_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAutoScale_updateResourceTracker(t *testing.T) {
+func Test_updateResourceTracker(t *testing.T) {
 	testCases := []struct {
 		group    string
 		cpu      int
@@ -33,5 +33,46 @@ func TestAutoScale_updateResourceTracker(t *testing.T) {
 	for _, tc := range testCases {
 		updateResourceTracker(tc.group, tc.cpu, tc.mem, tc.tracker)
 		assert.Equal(t, tc.expected, tc.tracker)
+	}
+}
+
+func Test_updateAutoscaleMeta(t *testing.T) {
+	testCases := []struct {
+		inputGroup         string
+		inputMetricType    string
+		inputValue         int
+		inputThreshold     int
+		inputMeta          map[string]string
+		expectedResultMeta map[string]string
+		name               string
+	}{
+		{
+			inputGroup:         "test",
+			inputMetricType:    "cpu",
+			inputValue:         90,
+			inputThreshold:     89,
+			inputMeta:          make(map[string]string),
+			expectedResultMeta: map[string]string{"test-cpu-value": "90", "test-cpu-threshold": "89"},
+			name:               "empty input meta",
+		},
+		{
+			inputGroup:      "test",
+			inputMetricType: "memory",
+			inputValue:      91,
+			inputThreshold:  89,
+			inputMeta:       map[string]string{"test-cpu-value": "90", "test-cpu-threshold": "89"},
+			expectedResultMeta: map[string]string{
+				"test-cpu-value":        "90",
+				"test-cpu-threshold":    "89",
+				"test-memory-value":     "91",
+				"test-memory-threshold": "89",
+			},
+			name: "existing input meta",
+		},
+	}
+
+	for _, tc := range testCases {
+		updateAutoscaleMeta(tc.inputGroup, tc.inputMetricType, tc.inputValue, tc.inputThreshold, tc.inputMeta)
+		assert.Equal(t, tc.expectedResultMeta, tc.inputMeta, tc.name)
 	}
 }


### PR DESCRIPTION
Previously the way the meta was built within the autoscaler only
meant a single metric could be tracked properly. This causes
misinformation as it is possible a scaling activity happens due
to greater than one resource breaking its threshold. This change
therefore updates the way the autoscaling meta is formed, to allow
for multiple resources to be tracked.