### PR TITLE
scale-meta: meta should be unique per job group.

### DIFF
--- a/pkg/scale/consts.go
+++ b/pkg/scale/consts.go
@@ -10,7 +10,7 @@ import (
 // Scale is the interface used for scaling a Nomad job.
 type Scale interface {
 	// Trigger performs scaling of 1 or more job groups which belong to the same job.
-	Trigger(string, []*GroupReq, state.Source, map[string]string) (*ScalingResponse, int, error)
+	Trigger(string, []*GroupReq, state.Source) (*ScalingResponse, int, error)
 
 	// GetDeploymentChannel is used to return the channel where updates to Nomad deployments should
 	// be sent.
@@ -57,6 +57,10 @@ type GroupReq struct {
 	// triggered. This is to help coordinate with checks such as cooldown and ensure a single time
 	// can be used.
 	Time int64
+
+	// Meta is the meta data which is optionally submitted when requesting a scaling activity for a
+	// job group. This is free-form and can contain any information the user deems relevant.
+	Meta map[string]string
 }
 
 type ScalingResponse struct {

--- a/pkg/scale/event.go
+++ b/pkg/scale/event.go
@@ -5,7 +5,7 @@ import (
 	"github.com/jrasell/sherpa/pkg/state"
 )
 
-func (s *Scaler) sendScalingEventToState(job, id string, source state.Source, groupReqs []*GroupReq, err error, meta map[string]string) uuid.UUID {
+func (s *Scaler) sendScalingEventToState(job, id string, source state.Source, groupReqs []*GroupReq, err error) uuid.UUID {
 
 	status := s.generateEventStatus(err)
 
@@ -24,7 +24,7 @@ func (s *Scaler) sendScalingEventToState(job, id string, source state.Source, gr
 			Time:      groupReqs[i].Time,
 			Count:     groupReqs[i].Count,
 			Direction: groupReqs[i].Direction.String(),
-			Meta:      meta,
+			Meta:      groupReqs[i].Meta,
 		}
 
 		if err := s.state.PutScalingEvent(job, &event); err != nil {

--- a/pkg/scale/scale.go
+++ b/pkg/scale/scale.go
@@ -44,7 +44,7 @@ func NewScaler(c *api.Client, l zerolog.Logger, state scale.Backend, strictCheck
 //		- the Nomad API job register response
 //		- the HTTP return code, used for the Sherpa API
 //		- any error
-func (s *Scaler) Trigger(jobID string, groupReqs []*GroupReq, source state.Source, meta map[string]string) (*ScalingResponse, int, error) {
+func (s *Scaler) Trigger(jobID string, groupReqs []*GroupReq, source state.Source) (*ScalingResponse, int, error) {
 
 	// In order to submit a job for scaling we need to read the entire job back to Nomad as it does
 	// not currently have convenience methods for changing job group counts.
@@ -80,11 +80,11 @@ func (s *Scaler) Trigger(jobID string, groupReqs []*GroupReq, source state.Sourc
 
 	resp, err := s.triggerNomadRegister(job)
 
-	return s.handleEndState(jobID, resp, err, groupReqs, source, meta)
+	return s.handleEndState(jobID, resp, err, groupReqs, source)
 }
 
 func (s *Scaler) handleEndState(job string, apiResp *api.JobRegisterResponse, apiErr error, groupReqs []*GroupReq,
-	source state.Source, meta map[string]string) (*ScalingResponse, int, error) {
+	source state.Source) (*ScalingResponse, int, error) {
 
 	eval := ""
 
@@ -92,7 +92,7 @@ func (s *Scaler) handleEndState(job string, apiResp *api.JobRegisterResponse, ap
 		eval = apiResp.EvalID
 	}
 
-	scaleID := s.sendScalingEventToState(job, eval, source, groupReqs, apiErr, meta)
+	scaleID := s.sendScalingEventToState(job, eval, source, groupReqs, apiErr)
 
 	if apiErr != nil {
 		return nil, http.StatusInternalServerError, apiErr

--- a/pkg/scale/v1/scale.go
+++ b/pkg/scale/v1/scale.go
@@ -55,7 +55,12 @@ func (s *Scale) InJobGroup(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	newReq := &scale.GroupReq{Direction: scale.DirectionIn, GroupName: groupID, Time: helper.GenerateEventTimestamp()}
+	newReq := &scale.GroupReq{
+		Direction: scale.DirectionIn,
+		GroupName: groupID,
+		Time:      helper.GenerateEventTimestamp(),
+		Meta:      body.Meta,
+	}
 
 	if s.scaler.JobGroupIsDeploying(jobID, groupID) {
 		s.logger.Info().
@@ -114,7 +119,7 @@ func (s *Scale) InJobGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	scaleResp, respCode, err := s.scaler.Trigger(jobID, []*scale.GroupReq{newReq}, state.SourceAPI, body.Meta)
+	scaleResp, respCode, err := s.scaler.Trigger(jobID, []*scale.GroupReq{newReq}, state.SourceAPI)
 	if err != nil {
 		s.logger.Error().
 			Err(err).
@@ -160,7 +165,12 @@ func (s *Scale) OutJobGroup(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	newReq := &scale.GroupReq{Direction: scale.DirectionOut, GroupName: groupID, Time: helper.GenerateEventTimestamp()}
+	newReq := &scale.GroupReq{
+		Direction: scale.DirectionOut,
+		GroupName: groupID,
+		Time:      helper.GenerateEventTimestamp(),
+		Meta:      body.Meta,
+	}
 
 	if s.scaler.JobGroupIsDeploying(jobID, groupID) {
 		s.logger.Info().
@@ -220,7 +230,7 @@ func (s *Scale) OutJobGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	scaleResp, respCode, err := s.scaler.Trigger(jobID, []*scale.GroupReq{newReq}, state.SourceAPI, body.Meta)
+	scaleResp, respCode, err := s.scaler.Trigger(jobID, []*scale.GroupReq{newReq}, state.SourceAPI)
 	if err != nil {
 		s.logger.Error().
 			Err(err).


### PR DESCRIPTION
The autoscaler works by analysing all groups within a job then
submitting the combined changes required to the scaler process to
action. Therefore the metadata sent with a request should be part
of the group request, not the function call allowing for metadata
to be unique per group.