### PR TITLE
Fix incorrect searching of allocs causing missed allocs in jobs.

### DIFF
--- a/pkg/autoscale/nomad.go
+++ b/pkg/autoscale/nomad.go
@@ -86,10 +86,10 @@ func (ae *autoscaleEvaluation) getJobAllocations() (map[string]*nomadResources, 
 		// GH-70: jobs can have a mix of groups with scaling policies, and groups without. We need
 		// to safely check the policy.
 		if v, ok := ae.policies[allocs[i].TaskGroup]; !ok {
-			break
+			continue
 		} else {
 			if !v.Enabled {
-				break
+				continue
 			}
 		}
 


### PR DESCRIPTION
When iterating a job that has multiple groups, 1 with and at least
1 without a scaling policy, the iteration was incorrectly ending
the loop early rather than continuing the iteration. This resulted
in scaling evaluations not correctly taking place and meaning jobs
that needed to scale where not able to do so.

closes #120 
