### PR TITLE
autoscale: pass group name to calculateExternalScalingDecision

### DIFF
--- a/pkg/autoscale/autoscale.go
+++ b/pkg/autoscale/autoscale.go
@@ -85,7 +85,7 @@ func (ae *autoscaleEvaluation) evaluateJob() {
 		// If the group has external checks, perform these and ensure the decision if not nil,
 		// before adding this to the decision tree.
 		if p.ExternalChecks != nil {
-			if extDec := ae.calculateExternalScalingDecision(ae.jobID, p); extDec != nil {
+			if extDec := ae.calculateExternalScalingDecision(group, p); extDec != nil {
 				externalDecision[group] = extDec
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What this PR does / why we need it**:
Fix nil pointer reference on `calculateExternalScalingDecision` call

**Which issue(s) this PR fixes**:
Fixes #127
